### PR TITLE
Implement log_limit

### DIFF
--- a/root/usr/share/firewall4/templates/redirect.uc
+++ b/root/usr/share/firewall4/templates/redirect.uc
@@ -61,6 +61,10 @@
 	{{ fw4.concat(redirect.ipset.fields) }}{{
 		redirect.ipset.invert ? ' !=' : ''
 	}} @{{ redirect.ipset.name }} {%+ endif -%}
+{%+ if (redirect.log && zone?.log_limit): -%}
+	limit name "{{ zone.name }}_log_limit" log prefix {{ fw4.quote(redirect.log, true) }}
+		{%+ include("redirect.uc", { fw4, zone, redirect: {...redirect, log:0 } }) %}
+{%+ else -%}
 {%+ if (redirect.counter): -%}
 	counter {%+ endif -%}
 {%+ if (redirect.log): -%}
@@ -73,3 +77,4 @@
 	{{ redirect.target }} {{ redirect.raddr ? fw4.host(redirect.raddr, redirect.rport != null) : '' }}
 	{%- if (redirect.rport): %}:{{ fw4.port(redirect.rport) }}{% endif %}
 {% endif %} comment {{ fw4.quote(`!fw4: ${redirect.name}`, true) }}
+{% endif -%}

--- a/root/usr/share/firewall4/templates/redirect.uc
+++ b/root/usr/share/firewall4/templates/redirect.uc
@@ -61,7 +61,10 @@
 	{{ fw4.concat(redirect.ipset.fields) }}{{
 		redirect.ipset.invert ? ' !=' : ''
 	}} @{{ redirect.ipset.name }} {%+ endif -%}
-{%+ if (redirect.log && zone?.log_limit): -%}
+{%+ if (redirect.log && redirect.log_limit): -%}
+	limit rate {{ redirect.log_limit.val }} log prefix {{ fw4.quote(redirect.log, true) }}
+		{%+ include("redirect.uc", { fw4, zone, redirect: {...redirect, log:0 } }) %}
+{%+ elif (redirect.log && zone?.log_limit): -%}
 	limit name "{{ zone.name }}_log_limit" log prefix {{ fw4.quote(redirect.log, true) }}
 		{%+ include("redirect.uc", { fw4, zone, redirect: {...redirect, log:0 } }) %}
 {%+ else -%}

--- a/root/usr/share/firewall4/templates/rule.uc
+++ b/root/usr/share/firewall4/templates/rule.uc
@@ -69,6 +69,10 @@
 	{{ fw4.concat(rule.ipset.fields) }}{{
 		rule.ipset.invert ? ' !=' : ''
 	}} @{{ rule.ipset.name }} {%+ endif -%}
+{%+ if (rule.log && zone?.log_limit): -%}
+	limit name "{{ zone.name }}_log_limit" log prefix {{ fw4.quote(rule.log, true) }}
+		{%+ include("rule.uc", { fw4, zone, rule: {...rule, log:0 } }) %}
+{%+ else -%}
 {%+ if (rule.counter): -%}
 	counter {%+ endif -%}
 {%+ if (rule.log): -%}
@@ -97,3 +101,4 @@
 	{{ rule.target }} {%+
    endif -%}
 comment {{ fw4.quote(`!fw4: ${rule.name}`, true) }}
+{%+ endif -%}

--- a/root/usr/share/firewall4/templates/rule.uc
+++ b/root/usr/share/firewall4/templates/rule.uc
@@ -69,7 +69,10 @@
 	{{ fw4.concat(rule.ipset.fields) }}{{
 		rule.ipset.invert ? ' !=' : ''
 	}} @{{ rule.ipset.name }} {%+ endif -%}
-{%+ if (rule.log && zone?.log_limit): -%}
+{%+ if (rule.log && rule.log_limit): -%}
+	limit rate {{ rule.log_limit.val }} log prefix {{ fw4.quote(rule.log, true) }}
+		{%+ include("rule.uc", { fw4, zone, rule: {...rule, log:0 } }) %}
+{%+ elif (rule.log && zone?.log_limit): -%}
 	limit name "{{ zone.name }}_log_limit" log prefix {{ fw4.quote(rule.log, true) }}
 		{%+ include("rule.uc", { fw4, zone, rule: {...rule, log:0 } }) %}
 {%+ else -%}

--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -108,7 +108,7 @@ table inet fw4 {
 		tcp flags & (fin | syn | rst | ack) == syn jump syn_flood comment "!fw4: Rate limit TCP syn packets"
 {% endif %}
 {% for (let rule in fw4.rules("input")): %}
-		{%+ include("rule.uc", { fw4, rule }) %}
+		{%+ include("rule.uc", { fw4, zone:null, rule }) %}
 {% endfor %}
 {% for (let zone in fw4.zones()): for (let rule in zone.match_rules): %}
 		{%+ include("zone-jump.uc", { fw4, zone, rule, direction: "input" }) %}
@@ -131,7 +131,7 @@ table inet fw4 {
 		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
 {% endif %}
 {% for (let rule in fw4.rules("forward")): %}
-		{%+ include("rule.uc", { fw4, rule }) %}
+		{%+ include("rule.uc", { fw4, zone:null, rule }) %}
 {% endfor %}
 {% for (let zone in fw4.zones()): for (let rule in zone.match_rules): %}
 		{%+ include("zone-jump.uc", { fw4, zone, rule, direction: "forward" }) %}
@@ -153,7 +153,7 @@ table inet fw4 {
 		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
 {% endif %}
 {% for (let rule in fw4.rules("output")): %}
-		{%+ include("rule.uc", { fw4, rule }) %}
+		{%+ include("rule.uc", { fw4, zone:null, rule }) %}
 {% endfor %}
 {% for (let zone in fw4.zones()): %}
 {%  for (let rule in zone.match_rules): %}
@@ -216,7 +216,7 @@ table inet fw4 {
 	chain input_{{ zone.name }} {
 {%  fw4.includes('chain-prepend', `input_${zone.name}`) %}
 {%  for (let rule in fw4.rules(`input_${zone.name}`)): %}
-		{%+ include("rule.uc", { fw4, rule }) %}
+		{%+ include("rule.uc", { fw4, zone, rule }) %}
 {%  endfor %}
 {%  if (zone.dflags.dnat): %}
 		ct status dnat accept comment "!fw4: Accept port redirections"
@@ -228,7 +228,7 @@ table inet fw4 {
 	chain output_{{ zone.name }} {
 {%  fw4.includes('chain-prepend', `output_${zone.name}`) %}
 {%  for (let rule in fw4.rules(`output_${zone.name}`)): %}
-		{%+ include("rule.uc", { fw4, rule }) %}
+		{%+ include("rule.uc", { fw4, zone, rule }) %}
 {%  endfor %}
 {%  fw4.includes('chain-append', `output_${zone.name}`) %}
 		jump {{ zone.output }}_to_{{ zone.name }}
@@ -237,7 +237,7 @@ table inet fw4 {
 	chain forward_{{ zone.name }} {
 {%  fw4.includes('chain-prepend', `forward_${zone.name}`) %}
 {%  for (let rule in fw4.rules(`forward_${zone.name}`)): %}
-		{%+ include("rule.uc", { fw4, rule }) %}
+		{%+ include("rule.uc", { fw4, zone, rule }) %}
 {%  endfor %}
 {%  if (zone.dflags.dnat): %}
 		ct status dnat accept comment "!fw4: Accept port forwards"
@@ -252,7 +252,7 @@ table inet fw4 {
 {%  if (zone.dflags.helper): %}
 	chain helper_{{ zone.name }} {
 {%   for (let rule in fw4.rules(`helper_${zone.name}`)): %}
-		{%+ include("rule.uc", { fw4, rule }) %}
+		{%+ include("rule.uc", { fw4, zone, rule }) %}
 {%   endfor %}
 	}
 
@@ -301,7 +301,7 @@ table inet fw4 {
 		type nat hook postrouting priority srcnat; policy accept;
 {% fw4.includes('chain-prepend', 'srcnat') %}
 {% for (let redirect in fw4.redirects("srcnat")): %}
-		{%+ include("redirect.uc", { fw4, redirect }) %}
+		{%+ include("redirect.uc", { fw4, zone:null, redirect }) %}
 {% endfor %}
 {% for (let zone in fw4.zones()): %}
 {%  if (zone.dflags.snat): %}
@@ -318,7 +318,7 @@ table inet fw4 {
 	chain dstnat_{{ zone.name }} {
 {%   fw4.includes('chain-prepend', `dstnat_${zone.name}`) %}
 {%   for (let redirect in fw4.redirects(`dstnat_${zone.name}`)): %}
-		{%+ include("redirect.uc", { fw4, redirect }) %}
+		{%+ include("redirect.uc", { fw4, zone, redirect }) %}
 {%   endfor %}
 {%   fw4.includes('chain-append', `dstnat_${zone.name}`) %}
 	}
@@ -328,7 +328,7 @@ table inet fw4 {
 	chain srcnat_{{ zone.name }} {
 {%   fw4.includes('chain-prepend', `srcnat_${zone.name}`) %}
 {%   for (let redirect in fw4.redirects(`srcnat_${zone.name}`)): %}
-		{%+ include("redirect.uc", { fw4, redirect }) %}
+		{%+ include("redirect.uc", { fw4, zone, redirect }) %}
 {%   endfor %}
 {%   if (zone.masq): %}
 {%    for (let saddrs in zone.masq4_src_subnets): %}
@@ -391,7 +391,7 @@ table inet fw4 {
 {%   if (zone.dflags.notrack): %}
 	chain notrack_{{ zone.name }} {
 {% for (let rule in fw4.rules(`notrack_${zone.name}`)): %}
-		{%+ include("rule.uc", { fw4, rule }) %}
+		{%+ include("rule.uc", { fw4, zone, rule }) %}
 {% endfor %}
 	}
 
@@ -406,7 +406,7 @@ table inet fw4 {
 		type filter hook prerouting priority mangle; policy accept;
 {% fw4.includes('chain-prepend', 'mangle_prerouting') %}
 {% for (let rule in fw4.rules("mangle_prerouting")): %}
-		{%+ include("rule.uc", { fw4, rule }) %}
+		{%+ include("rule.uc", { fw4, zone:null, rule }) %}
 {% endfor %}
 {% fw4.includes('chain-append', 'mangle_prerouting') %}
 	}
@@ -415,7 +415,7 @@ table inet fw4 {
 		type filter hook postrouting priority mangle; policy accept;
 {% fw4.includes('chain-prepend', 'mangle_postrouting') %}
 {% for (let rule in fw4.rules("mangle_postrouting")): %}
-		{%+ include("rule.uc", { fw4, rule }) %}
+		{%+ include("rule.uc", { fw4, zone:null, rule }) %}
 {% endfor %}
 {% fw4.includes('chain-append', 'mangle_postrouting') %}
 	}
@@ -424,7 +424,7 @@ table inet fw4 {
 		type filter hook input priority mangle; policy accept;
 {% fw4.includes('chain-prepend', 'mangle_input') %}
 {% for (let rule in fw4.rules("mangle_input")): %}
-		{%+ include("rule.uc", { fw4, rule }) %}
+		{%+ include("rule.uc", { fw4, zone:null, rule }) %}
 {% endfor %}
 {% fw4.includes('chain-append', 'mangle_input') %}
 	}
@@ -433,7 +433,7 @@ table inet fw4 {
 		type route hook output priority mangle; policy accept;
 {% fw4.includes('chain-prepend', 'mangle_output') %}
 {% for (let rule in fw4.rules("mangle_output")): %}
-		{%+ include("rule.uc", { fw4, rule }) %}
+		{%+ include("rule.uc", { fw4, zone:null, rule }) %}
 {% endfor %}
 {% fw4.includes('chain-append', 'mangle_output') %}
 	}
@@ -442,7 +442,7 @@ table inet fw4 {
 		type filter hook forward priority mangle; policy accept;
 {% fw4.includes('chain-prepend', 'mangle_forward') %}
 {% for (let rule in fw4.rules("mangle_forward")): %}
-		{%+ include("rule.uc", { fw4, rule }) %}
+		{%+ include("rule.uc", { fw4, zone:null, rule }) %}
 {% endfor %}
 {% for (let zone in fw4.zones()): %}
 {%  if (zone.mtu_fix): %}

--- a/root/usr/share/firewall4/templates/zone-drop-invalid.uc
+++ b/root/usr/share/firewall4/templates/zone-drop-invalid.uc
@@ -1,8 +1,12 @@
 {%+ if (zone.masq ^ zone.masq6): -%}
 	meta nfproto {{ fw4.nfproto(zone.masq ? 4 : 6) }} {%+ endif -%}
 {%+  include("zone-match.uc", { egress: true, rule }) -%}
-ct state invalid {%+ if (zone.counter): -%}
+ct state invalid {%+ if ((zone.log & 1) && zone.log_limit): -%}
+	limit name "{{ zone.name }}_log_limit" log prefix "drop {{ zone.name }} invalid ct state: "
+		{%+ include("zone-drop-invalid.uc", { fw4, zone: {...zone, log:0 }, rule }) %}
+{%+ else -%}{%+ if (zone.counter): -%}
 	counter {%+ endif -%}
 {%+ if (zone.log & 1): -%}
 	log prefix "drop {{ zone.name }} invalid ct state: " {%+ endif -%}
 drop comment "!fw4: Prevent NAT leakage"
+{%+ endif -%}

--- a/root/usr/share/firewall4/templates/zone-verdict.uc
+++ b/root/usr/share/firewall4/templates/zone-verdict.uc
@@ -1,6 +1,10 @@
 {%+ if (rule.family): -%}
 	meta nfproto {{ fw4.nfproto(rule.family) }} {%+ endif -%}
 {%+ include("zone-match.uc", { egress, rule }) -%}
+{%+ if (verdict != "accept" && (zone.log & 1) && zone.log_limit): -%}
+	limit name "{{ zone.name }}_log_limit" log prefix "{{ verdict }} {{ zone.name }} {{ egress ? "out" : "in" }}:"
+		{%+ include("zone-verdict.uc", { fw4, zone: {...zone, log:0 }, rule, egress, verdict }) %}
+{%+ else -%}
 {%+ if (zone.counter): -%}
 	counter {%+ endif -%}
 {%+ if (verdict != "accept" && (zone.log & 1)): -%}
@@ -9,4 +13,5 @@
 	jump handle_reject comment "!fw4: reject {{ zone.name }} {{ fw4.nfproto(rule.family, true) }} traffic"
 {% else -%}
 	{{ verdict }} comment "!fw4: {{ verdict }} {{ zone.name }} {{ fw4.nfproto(rule.family, true) }} traffic"
+{% endif -%}
 {% endif -%}

--- a/root/usr/share/ucode/fw4.uc
+++ b/root/usr/share/ucode/fw4.uc
@@ -1994,7 +1994,7 @@ return {
 			custom_chains: [ "bool", null, UNSUPPORTED ],
 
 			log: [ "int" ],
-			log_limit: [ "limit", null, UNSUPPORTED ],
+			log_limit: [ "limit" ],
 
 			auto_helper: [ "bool", "1" ],
 			helper: [ "cthelper", null, PARSE_LIST ],

--- a/root/usr/share/ucode/fw4.uc
+++ b/root/usr/share/ucode/fw4.uc
@@ -2321,6 +2321,7 @@ return {
 
 			counter: [ "bool", "1" ],
 			log: [ "string" ],
+			log_limit: [ "limit" ],
 
 			target: [ "target" ]
 		});
@@ -2637,6 +2638,7 @@ return {
 
 			counter: [ "bool", "1" ],
 			log: [ "string" ],
+			log_limit: [ "limit" ],
 
 			target: [ "target", "dnat" ]
 		});

--- a/tests/02_zones/08_log_limit
+++ b/tests/02_zones/08_log_limit
@@ -139,6 +139,14 @@ specified or not.
 			"dest": "wan",
 			"src_ip": [ "192.168.1.3" ],
 			"target": "drop"
+		},
+		{
+			".description": "src any log",
+			"proto": "tcp",
+			"src": "*",
+			"dest_port": 1009,
+			"log": 1,
+			"log_limit": "5/min"
 		}
 	],
 	"redirect": [
@@ -149,7 +157,17 @@ specified or not.
 			"dest_ip": "10.0.0.2",
 			"dest_port": "22",
 			"log": "1"
+		},
+		{
+			"proto": "tcp",
+			"src": "wan",
+			"dest": "lan",
+			"dest_ip": "10.0.0.2",
+			"dest_port": "23",
+			"log": "1",
+			"log_limit": "4/min"
 		}
+
 	]
 }
 -- End --
@@ -210,6 +228,8 @@ table inet fw4 {
 		ct state established,related accept comment "!fw4: Allow inbound established and related flows"
 		tcp dport 1007 counter log prefix "@rule[6]: " comment "!fw4: @rule[6]"
 		tcp dport 1008 counter comment "!fw4: @rule[7]"
+		tcp dport 1009 limit rate 5/min log prefix "@rule[12]: "
+		tcp dport 1009 counter comment "!fw4: @rule[12]"
 		iifname "br-lan" jump input_lan comment "!fw4: Handle lan IPv4/IPv6 input traffic"
 		iifname "pppoe-wan" jump input_wan comment "!fw4: Handle wan IPv4/IPv6 input traffic"
 		iifname "br-guest" jump input_guest comment "!fw4: Handle guest IPv4/IPv6 input traffic"
@@ -358,15 +378,19 @@ table inet fw4 {
 
 	chain dstnat_lan {
 		ip saddr { 10.0.0.0/24, 192.168.26.0/24 } ip daddr 10.11.12.194 dnat 10.0.0.2:22 comment "!fw4: @redirect[0] (reflection)"
+		ip saddr { 10.0.0.0/24, 192.168.26.0/24 } ip daddr 10.11.12.194 dnat 10.0.0.2:23 comment "!fw4: @redirect[1] (reflection)"
 	}
 
 	chain srcnat_lan {
 		ip saddr { 10.0.0.0/24, 192.168.26.0/24 } ip daddr 10.0.0.2 tcp dport 22 snat 10.0.0.1 comment "!fw4: @redirect[0] (reflection)"
+		ip saddr { 10.0.0.0/24, 192.168.26.0/24 } ip daddr 10.0.0.2 tcp dport 23 snat 10.0.0.1 comment "!fw4: @redirect[1] (reflection)"
 	}
 
 	chain dstnat_wan {
 		meta nfproto ipv4 limit name "wan_log_limit" log prefix "@redirect[0]: "
 		meta nfproto ipv4 counter dnat 10.0.0.2:22 comment "!fw4: @redirect[0]"
+		meta nfproto ipv4 limit rate 4/min log prefix "@redirect[1]: "
+		meta nfproto ipv4 counter dnat 10.0.0.2:23 comment "!fw4: @redirect[1]"
 	}
 
 	chain srcnat_wan {

--- a/tests/02_zones/08_log_limit
+++ b/tests/02_zones/08_log_limit
@@ -1,0 +1,414 @@
+Test that the zone family is honoured regardless of whether subnets are
+specified or not.
+
+-- Testcase --
+{%
+	include("./root/usr/share/firewall4/main.uc", {
+		getenv: function(varname) {
+			switch (varname) {
+			case 'ACTION':
+				return 'print';
+			}
+		}
+	})
+%}
+-- End --
+
+-- File uci/firewall.json --
+{
+	"zone": [
+		{
+			".description": "test zone with log_limit",
+			"name": "lan",
+			"network": "lan",
+			"auto_helper": 0,
+			"log": 3,
+			"log_limit": "1/min"
+		},
+		{
+			".description": "test zone with MASQ and log_limit",
+			"name": "wan",
+			"network": "wan",
+			"auto_helper": 0,
+			"masq": 1,
+			"log": 3,
+			"log_limit": "2/min"
+		},
+		{
+			".description": "test zone with log_limit and no log",
+			"name": "guest",
+			"network": "guest",
+			"auto_helper": 0,
+			"log_limit": "3/min"
+		},
+
+	],
+
+
+	"forwarding": [
+		{
+			"src": "lan",
+			"dest": "wan"
+		}
+	],
+
+	"rule": [
+		{
+			".description": "src lan log",
+			"proto": "tcp",
+			"src": "lan",
+			"dest_port": 1001,
+			"log": 1
+		},
+		{
+			".description": "src lan no log",
+			"proto": "tcp",
+			"src": "lan",
+			"dest_port": 1002,
+			"log": 0
+		},
+		{
+			".description": "dest lan log",
+			"proto": "tcp",
+			"dest": "lan",
+			"dest_port": 1003,
+			"log": 1
+		},
+		{
+			".description": "dest lan no log",
+			"proto": "tcp",
+			"dest": "lan",
+			"dest_port": 1004,
+			"log": 0
+		},
+		{
+			".description": "Source any, dest lan, log",
+			"proto": "tcp",
+			"src": "*",
+			"dest": "lan",
+			"dest_port": 1005,
+			"log": 1
+		},
+		{
+			".description": "Source any, dest lan, no log",
+			"proto": "tcp",
+			"src": "*",
+			"dest": "lan",
+			"dest_port": 1006,
+			"log": 0
+		},
+		{
+			".description": "src any log",
+			"proto": "tcp",
+			"src": "*",
+			"dest_port": 1007,
+			"log": 1
+		},
+		{
+			".description": "src any no log",
+			"proto": "tcp",
+			"src": "*",
+			"dest_port": 1008,
+			"log": 0
+		},
+		{
+			"name": "Deny guest with no log",
+			"proto": "icmp",
+			"dest": "guest",
+			"target": "drop"
+		},
+		{
+			"name": "Deny guest with log",
+			"proto": "icmp",
+			"dest": "guest",
+			"target": "drop",
+			"log": 1
+		},
+		{
+			"name": "Deny rule #1",
+			"proto": "any",
+			"src": "lan",
+			"dest": "wan",
+			"src_ip": [ "192.168.1.2" ],
+			"target": "drop"
+		},
+		{
+			"name": "Deny rule #2",
+			"proto": "icmp",
+			"src": "lan",
+			"dest": "wan",
+			"src_ip": [ "192.168.1.3" ],
+			"target": "drop"
+		}
+	],
+	"redirect": [
+		{
+			"proto": "tcp",
+			"src": "wan",
+			"dest": "lan",
+			"dest_ip": "10.0.0.2",
+			"dest_port": "22",
+			"log": "1"
+		}
+	]
+}
+-- End --
+
+
+-- End --
+
+-- File uci/helpers.json --
+{}
+-- End --
+
+-- Expect stdout --
+table inet fw4
+flush table inet fw4
+
+table inet fw4 {
+	#
+	# Defines
+	#
+
+	define lan_devices = { "br-lan" }
+	define lan_subnets = { 10.0.0.0/24, 192.168.26.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
+
+	define wan_devices = { "pppoe-wan" }
+	define wan_subnets = { 10.11.12.0/24 }
+
+	define guest_devices = { "br-guest" }
+	define guest_subnets = { 10.1.0.0/24, 192.168.27.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
+
+
+	#
+	# Limits
+	#
+
+	limit lan_log_limit { rate 1/min ; comment "lan log limit"; }
+
+	limit wan_log_limit { rate 2/min ; comment "wan log limit"; }
+
+	limit guest_log_limit { rate 3/min ; comment "guest log limit"; }
+
+
+	#
+	# User includes
+	#
+
+	include "/etc/nftables.d/*.nft"
+
+
+	#
+	# Filter rules
+	#
+
+	chain input {
+		type filter hook input priority filter; policy drop;
+
+		iifname "lo" accept comment "!fw4: Accept traffic from loopback"
+
+		ct state established,related accept comment "!fw4: Allow inbound established and related flows"
+		tcp dport 1007 counter log prefix "@rule[6]: " comment "!fw4: @rule[6]"
+		tcp dport 1008 counter comment "!fw4: @rule[7]"
+		iifname "br-lan" jump input_lan comment "!fw4: Handle lan IPv4/IPv6 input traffic"
+		iifname "pppoe-wan" jump input_wan comment "!fw4: Handle wan IPv4/IPv6 input traffic"
+		iifname "br-guest" jump input_guest comment "!fw4: Handle guest IPv4/IPv6 input traffic"
+	}
+
+	chain forward {
+		type filter hook forward priority filter; policy drop;
+
+		ct state established,related accept comment "!fw4: Allow forwarded established and related flows"
+		tcp dport 1005 limit name "lan_log_limit" log prefix "@rule[4]: "
+		tcp dport 1005 counter comment "!fw4: @rule[4]"
+		tcp dport 1006 counter comment "!fw4: @rule[5]"
+		iifname "br-lan" jump forward_lan comment "!fw4: Handle lan IPv4/IPv6 forward traffic"
+		iifname "pppoe-wan" jump forward_wan comment "!fw4: Handle wan IPv4/IPv6 forward traffic"
+		iifname "br-guest" jump forward_guest comment "!fw4: Handle guest IPv4/IPv6 forward traffic"
+	}
+
+	chain output {
+		type filter hook output priority filter; policy drop;
+
+		oifname "lo" accept comment "!fw4: Accept traffic towards loopback"
+
+		ct state established,related accept comment "!fw4: Allow outbound established and related flows"
+		oifname "br-lan" jump output_lan comment "!fw4: Handle lan IPv4/IPv6 output traffic"
+		oifname "pppoe-wan" jump output_wan comment "!fw4: Handle wan IPv4/IPv6 output traffic"
+		oifname "br-guest" jump output_guest comment "!fw4: Handle guest IPv4/IPv6 output traffic"
+	}
+
+	chain prerouting {
+		type filter hook prerouting priority filter; policy accept;
+	}
+
+	chain handle_reject {
+		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
+		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
+	}
+
+	chain input_lan {
+		tcp dport 1001 limit name "lan_log_limit" log prefix "@rule[0]: "
+		tcp dport 1001 counter comment "!fw4: @rule[0]"
+		tcp dport 1002 counter comment "!fw4: @rule[1]"
+		ct status dnat accept comment "!fw4: Accept port redirections"
+		jump drop_from_lan
+	}
+
+	chain output_lan {
+		tcp dport 1003 limit name "lan_log_limit" log prefix "@rule[2]: "
+		tcp dport 1003 counter comment "!fw4: @rule[2]"
+		tcp dport 1004 counter comment "!fw4: @rule[3]"
+		jump drop_to_lan
+	}
+
+	chain forward_lan {
+		ip saddr 192.168.1.2 counter jump drop_to_wan comment "!fw4: Deny rule #1"
+		meta l4proto icmp ip saddr 192.168.1.3 counter jump drop_to_wan comment "!fw4: Deny rule #2"
+		jump accept_to_wan comment "!fw4: Accept lan to wan forwarding"
+		ct status dnat accept comment "!fw4: Accept port forwards"
+		jump drop_to_lan
+		limit name "lan_log_limit" log prefix "drop lan forward: "
+	}
+
+	chain accept_to_lan {
+		oifname "br-lan" counter accept comment "!fw4: accept lan IPv4/IPv6 traffic"
+	}
+
+	chain drop_from_lan {
+		iifname "br-lan" limit name "lan_log_limit" log prefix "drop lan in:"
+		iifname "br-lan" counter drop comment "!fw4: drop lan IPv4/IPv6 traffic"
+	}
+
+	chain drop_to_lan {
+		oifname "br-lan" limit name "lan_log_limit" log prefix "drop lan out:"
+		oifname "br-lan" counter drop comment "!fw4: drop lan IPv4/IPv6 traffic"
+	}
+
+	chain input_wan {
+		ct status dnat accept comment "!fw4: Accept port redirections"
+		jump drop_from_wan
+	}
+
+	chain output_wan {
+		jump drop_to_wan
+	}
+
+	chain forward_wan {
+		ct status dnat accept comment "!fw4: Accept port forwards"
+		jump drop_to_wan
+		limit name "wan_log_limit" log prefix "drop wan forward: "
+	}
+
+	chain accept_to_wan {
+		meta nfproto ipv4 oifname "pppoe-wan" ct state invalid limit name "wan_log_limit" log prefix "drop wan invalid ct state: "
+		meta nfproto ipv4 oifname "pppoe-wan" ct state invalid counter drop comment "!fw4: Prevent NAT leakage"
+		oifname "pppoe-wan" counter accept comment "!fw4: accept wan IPv4/IPv6 traffic"
+	}
+
+	chain drop_from_wan {
+		iifname "pppoe-wan" limit name "wan_log_limit" log prefix "drop wan in:"
+		iifname "pppoe-wan" counter drop comment "!fw4: drop wan IPv4/IPv6 traffic"
+	}
+
+	chain drop_to_wan {
+		oifname "pppoe-wan" limit name "wan_log_limit" log prefix "drop wan out:"
+		oifname "pppoe-wan" counter drop comment "!fw4: drop wan IPv4/IPv6 traffic"
+	}
+
+	chain input_guest {
+		jump drop_from_guest
+	}
+
+	chain output_guest {
+		meta l4proto { "icmp", "ipv6-icmp" } counter jump drop_to_guest comment "!fw4: Deny guest with no log"
+		meta l4proto { "icmp", "ipv6-icmp" } limit name "guest_log_limit" log prefix "Deny guest with log: "
+		meta l4proto { "icmp", "ipv6-icmp" } counter jump drop_to_guest comment "!fw4: Deny guest with log"
+		jump drop_to_guest
+	}
+
+	chain forward_guest {
+		jump drop_to_guest
+	}
+
+	chain drop_from_guest {
+		iifname "br-guest" counter drop comment "!fw4: drop guest IPv4/IPv6 traffic"
+	}
+
+	chain drop_to_guest {
+		oifname "br-guest" counter drop comment "!fw4: drop guest IPv4/IPv6 traffic"
+	}
+
+
+	#
+	# NAT rules
+	#
+
+	chain dstnat {
+		type nat hook prerouting priority dstnat; policy accept;
+		iifname "br-lan" jump dstnat_lan comment "!fw4: Handle lan IPv4/IPv6 dstnat traffic"
+		iifname "pppoe-wan" jump dstnat_wan comment "!fw4: Handle wan IPv4/IPv6 dstnat traffic"
+	}
+
+	chain srcnat {
+		type nat hook postrouting priority srcnat; policy accept;
+		oifname "br-lan" jump srcnat_lan comment "!fw4: Handle lan IPv4/IPv6 srcnat traffic"
+		oifname "pppoe-wan" jump srcnat_wan comment "!fw4: Handle wan IPv4/IPv6 srcnat traffic"
+	}
+
+	chain dstnat_lan {
+		ip saddr { 10.0.0.0/24, 192.168.26.0/24 } ip daddr 10.11.12.194 dnat 10.0.0.2:22 comment "!fw4: @redirect[0] (reflection)"
+	}
+
+	chain srcnat_lan {
+		ip saddr { 10.0.0.0/24, 192.168.26.0/24 } ip daddr 10.0.0.2 tcp dport 22 snat 10.0.0.1 comment "!fw4: @redirect[0] (reflection)"
+	}
+
+	chain dstnat_wan {
+		meta nfproto ipv4 limit name "wan_log_limit" log prefix "@redirect[0]: "
+		meta nfproto ipv4 counter dnat 10.0.0.2:22 comment "!fw4: @redirect[0]"
+	}
+
+	chain srcnat_wan {
+		meta nfproto ipv4 masquerade comment "!fw4: Masquerade IPv4 wan traffic"
+	}
+
+
+	#
+	# Raw rules (notrack)
+	#
+
+	chain raw_prerouting {
+		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain raw_output {
+		type filter hook output priority raw; policy accept;
+	}
+
+
+	#
+	# Mangle rules
+	#
+
+	chain mangle_prerouting {
+		type filter hook prerouting priority mangle; policy accept;
+	}
+
+	chain mangle_postrouting {
+		type filter hook postrouting priority mangle; policy accept;
+	}
+
+	chain mangle_input {
+		type filter hook input priority mangle; policy accept;
+	}
+
+	chain mangle_output {
+		type route hook output priority mangle; policy accept;
+	}
+
+	chain mangle_forward {
+		type filter hook forward priority mangle; policy accept;
+	}
+}
+-- End --


### PR DESCRIPTION
Without a log_limit, the router with logs enabled in a zone is vulnerable to a DoS attack, with potential traffic amplification if the router sends the log to a syslog server.

With fw3, the router was handling about 60k/h, with peaks of 70k/h. After the upgrade to fw4, the same router started to send reject messages at 320k/h, increasing the routed traffic latency to about 2000ms. I don't know if fw4 is simply generating more logs with the same traffic or if fw3 had an implicit log limit (intentional or not). Maybe fw4 should have an implicit log limit as well.

This series implement the log_limit that was missing in fw4. It creates a dedicated rule only for log action before the other action rules. Also, it adds log_rate to rules (to let the user fine tune log rate for important rules).

It still lacks the test cases but the existing one were updated to deal with the dedicated log rule. I'll add those tests after this PR idea got accepted.