### PR TITLE
Apply MSS fixup in place with final MTU before wire.

### DIFF
--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -417,6 +417,13 @@ table inet fw4 {
 {% for (let rule in fw4.rules("mangle_postrouting")): %}
 		{%+ include("rule.uc", { fw4, rule }) %}
 {% endfor %}
+{% for (let zone in fw4.zones()): %}
+{%  if (zone.mtu_fix): %}
+{%   for (let rule in zone.match_rules): %}
+                {%+ include("zone-mssfix.uc", { fw4, zone, rule, egress: true }) %}
+{%   endfor %}
+{%  endif %}
+{% endfor %}
 {% fw4.includes('chain-append', 'mangle_postrouting') %}
 	}
 
@@ -443,14 +450,6 @@ table inet fw4 {
 {% fw4.includes('chain-prepend', 'mangle_forward') %}
 {% for (let rule in fw4.rules("mangle_forward")): %}
 		{%+ include("rule.uc", { fw4, rule }) %}
-{% endfor %}
-{% for (let zone in fw4.zones()): %}
-{%  if (zone.mtu_fix): %}
-{%   for (let rule in zone.match_rules): %}
-		{%+ include("zone-mssfix.uc", { fw4, zone, rule, egress: false }) %}
-		{%+ include("zone-mssfix.uc", { fw4, zone, rule, egress: true }) %}
-{%   endfor %}
-{%  endif %}
 {% endfor %}
 {% fw4.includes('chain-append', 'mangle_forward') %}
 	}

--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -420,7 +420,7 @@ table inet fw4 {
 {% for (let zone in fw4.zones()): %}
 {%  if (zone.mtu_fix): %}
 {%   for (let rule in zone.match_rules): %}
-                {%+ include("zone-mssfix.uc", { fw4, zone, rule, egress: true }) %}
+		{%+ include("zone-mssfix.uc", { fw4, zone, rule, egress: true }) %}
 {%   endfor %}
 {%  endif %}
 {% endfor %}
@@ -450,6 +450,13 @@ table inet fw4 {
 {% fw4.includes('chain-prepend', 'mangle_forward') %}
 {% for (let rule in fw4.rules("mangle_forward")): %}
 		{%+ include("rule.uc", { fw4, rule }) %}
+{% endfor %}
+{% for (let zone in fw4.zones()): %}
+{%  if (zone.mtu_fix): %}
+{%   for (let rule in zone.match_rules): %}
+		{%+ include("zone-mssfix.uc", { fw4, zone, rule, egress: false }) %}
+{%   endfor %}
+{%  endif %}
 {% endfor %}
 {% fw4.includes('chain-append', 'mangle_forward') %}
 	}

--- a/root/usr/share/firewall4/templates/zone-mssfix.uc
+++ b/root/usr/share/firewall4/templates/zone-mssfix.uc
@@ -1,7 +1,7 @@
 {%+ if (rule.family): -%}
 	meta nfproto {{ fw4.nfproto(rule.family) }} {%+ endif -%}
 {%+ include("zone-match.uc", { egress, rule }) -%}
-tcp flags syn tcp option maxseg size set rt mtu {%+ if (zone.log & 2): -%}
+tcp flags syn / syn,fin,rst tcp option maxseg size set rt mtu {%+ if (zone.log & 2): -%}
 	log prefix "MSSFIX {{ zone.name }} out: " {%+ endif -%}
 comment "!fw4: Zone {{ zone.name }} {{
 	fw4.nfproto(rule.family, true)

--- a/tests/01_configuration/01_ruleset
+++ b/tests/01_configuration/01_ruleset
@@ -269,6 +269,7 @@ table inet fw4 {
 
 	chain mangle_postrouting {
 		type filter hook postrouting priority mangle; policy accept;
+		oifname "pppoe-wan" tcp flags syn / syn,fin,rst tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4/IPv6 egress MTU fixing"
 	}
 
 	chain mangle_input {
@@ -281,8 +282,7 @@ table inet fw4 {
 
 	chain mangle_forward {
 		type filter hook forward priority mangle; policy accept;
-		iifname "pppoe-wan" tcp flags syn tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4/IPv6 ingress MTU fixing"
-		oifname "pppoe-wan" tcp flags syn tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4/IPv6 egress MTU fixing"
+		iifname "pppoe-wan" tcp flags syn / syn,fin,rst tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4/IPv6 ingress MTU fixing"
 	}
 }
 -- End --


### PR DESCRIPTION
- locate mss fixup in postrouting table so that final route MTU is used in nat/docker forwarding and mwan scenario where incoming, most likely 1500 was applied
-  reduce scope of fixup to only legit SYN and SYN+ACK packets potentially pertaining connection establishment
-  one final rule 2x faster than existing 2

Fixes: https://github.com/openwrt/openwrt/issues/12112
Part-fixes: https://github.com/openwrt/openwrt/issues/12805

Signed-Off-By: `Andris PE <neandris..gmail.com>`