### PR TITLE
Disable loopback state tracking to match firewall3

### DIFF
--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -99,7 +99,7 @@ table inet fw4 {
 
 {% fw4.includes('chain-prepend', 'input') %}
 		ct state established,related accept comment "!fw4: Allow inbound established and related flows"
-		iifname "lo" notrack accept comment "!fw4: Accept traffic from loopback"
+		iifname "lo" accept comment "!fw4: Accept traffic from loopback"
 {% if (fw4.default_option("drop_invalid")): %}
 		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
 {% endif %}
@@ -145,7 +145,7 @@ table inet fw4 {
 		type filter hook output priority filter; policy {{ fw4.output_policy(true) }};
 {% fw4.includes('chain-prepend', 'output') %}
 		ct state established,related accept comment "!fw4: Allow outbound established and related flows"
-		oifname "lo" notrack accept comment "!fw4: Accept traffic towards loopback"
+		oifname "lo" accept comment "!fw4: Accept traffic towards loopback"
 {% if (fw4.default_option("drop_invalid")): %}
 		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
 {% endif %}

--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -96,10 +96,9 @@ table inet fw4 {
 
 	chain input {
 		type filter hook input priority filter; policy {{ fw4.input_policy(true) }};
-
+		iifname "lo" accept comment "!fw4: Accept traffic from loopback"
 {% fw4.includes('chain-prepend', 'input') %}
 		ct state established,related accept comment "!fw4: Allow inbound established and related flows"
-		iifname "lo" accept comment "!fw4: Accept traffic from loopback"
 {% if (fw4.default_option("drop_invalid")): %}
 		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
 {% endif %}
@@ -143,9 +142,9 @@ table inet fw4 {
 
 	chain output {
 		type filter hook output priority filter; policy {{ fw4.output_policy(true) }};
+		oifname "lo" accept comment "!fw4: Accept traffic towards loopback"
 {% fw4.includes('chain-prepend', 'output') %}
 		ct state established,related accept comment "!fw4: Allow outbound established and related flows"
-		oifname "lo" accept comment "!fw4: Accept traffic towards loopback"
 {% if (fw4.default_option("drop_invalid")): %}
 		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
 {% endif %}
@@ -353,6 +352,7 @@ table inet fw4 {
 
 	chain raw_prerouting {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "lo" notrack
 {% for (let zone in fw4.zones()): %}
 {%  if (zone.dflags["notrack"]): %}
 {%   for (let rule in zone.match_rules): %}
@@ -369,6 +369,7 @@ table inet fw4 {
 
 	chain raw_output {
 		type filter hook output priority raw; policy accept;
+		oifname "lo" notrack
 {% fw4.includes('chain-prepend', 'raw_output') %}
 {% for (let zone in fw4.zones()): %}
 {%  if (zone.dflags["notrack"]): %}

--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -97,10 +97,9 @@ table inet fw4 {
 	chain input {
 		type filter hook input priority filter; policy {{ fw4.input_policy(true) }};
 
-		iifname "lo" accept comment "!fw4: Accept traffic from loopback"
-
 {% fw4.includes('chain-prepend', 'input') %}
 		ct state established,related accept comment "!fw4: Allow inbound established and related flows"
+		iifname "lo" notrack accept comment "!fw4: Accept traffic from loopback"
 {% if (fw4.default_option("drop_invalid")): %}
 		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
 {% endif %}
@@ -144,11 +143,9 @@ table inet fw4 {
 
 	chain output {
 		type filter hook output priority filter; policy {{ fw4.output_policy(true) }};
-
-		oifname "lo" accept comment "!fw4: Accept traffic towards loopback"
-
 {% fw4.includes('chain-prepend', 'output') %}
 		ct state established,related accept comment "!fw4: Allow outbound established and related flows"
+		oifname "lo" notrack accept comment "!fw4: Accept traffic towards loopback"
 {% if (fw4.default_option("drop_invalid")): %}
 		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
 {% endif %}


### PR DESCRIPTION
- disable conntrack-ing loopback connections akin iptables-legacy https://github.com/openwrt/openwrt/issues/12522

old iptables treated all rules before first conntrack rule as stateless, with nftables this became unnecessary flexing of conntrack before it actually does anything useful.

- enact positive state machine first before per-packet examination

While pre-bulk per-packet processing is drastically reduced, still accept conntrack matches first as done with conntrack offloads. 

Fixes: https://github.com/openwrt/openwrt/issues/12522
Signed-Off-By: `Andris PE <neandris..gmail.com>`