### PR TITLE
Fix excess responses on noisy WAN network 

### DIFF
--- a/root/etc/config/firewall
+++ b/root/etc/config/firewall
@@ -2,7 +2,7 @@ config defaults
 	option syn_flood	1
 	option input		REJECT
 	option output		ACCEPT
-	option forward		REJECT
+	option forward		DROP
 # Uncomment this line to disable ipv6 rules
 #	option disable_ipv6	1
 

--- a/root/etc/config/firewall
+++ b/root/etc/config/firewall
@@ -2,7 +2,7 @@ config defaults
 	option syn_flood	1
 	option input		REJECT
 	option output		ACCEPT
-	option forward		DROP
+	option forward		REJECT
 # Uncomment this line to disable ipv6 rules
 #	option disable_ipv6	1
 

--- a/root/etc/config/firewall
+++ b/root/etc/config/firewall
@@ -19,7 +19,7 @@ config zone
 	list   network		'wan6'
 	option input		REJECT
 	option output		ACCEPT
-	option forward		REJECT
+	option forward		DROP
 	option masq		1
 	option mtu_fix		1
 


### PR DESCRIPTION
Fixes: https://github.com/openwrt/openwrt/issues/13340

In principle there is nothing forwarded from WAN unless some forward rule is present or it tries NAT traversal on recent new connection attempt. Past fixing excessive load generated in reported case also nat traversal will not need to retry socket connection, retransmitted SYN is likely to come when permitting rule/transient state is completely established.

 Signed-Off-By: `Andris PE <neandris..gmail.com>`