### PR TITLE
Remove duplicate interface list match in verdict chain

### DIFF
--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -260,20 +260,20 @@ table inet fw4 {
 {%  for (let verdict in ["accept", "reject", "drop"]): %}
 {%   if (zone.sflags[verdict]): %}
 	chain {{ verdict }}_from_{{ zone.name }} {
-{%    for (let rule in zone.match_rules): %}
+# {%    for (let rule in zone.match_rules): %}
 		{%+ include("zone-verdict.uc", { fw4, zone, rule, egress: false, verdict }) %}
-{%    endfor %}
+# {%    endfor %}
 	}
 
 {%   endif %}
 {%   if (zone.dflags[verdict]): %}
 	chain {{ verdict }}_to_{{ zone.name }} {
-{%   for (let rule in zone.match_rules): %}
+# {%   for (let rule in zone.match_rules): %}
 {%     if (verdict == "accept" && (zone.masq || zone.masq6) && !zone.masq_allow_invalid): %}
 		{%+ include("zone-drop-invalid.uc", { fw4, zone, rule }) %}
 {%     endif %}
 		{%+ include("zone-verdict.uc", { fw4, zone, rule, egress: true, verdict }) %}
-{%   endfor %}
+# {%   endfor %}
 	}
 
 {%   endif %}

--- a/root/usr/share/firewall4/templates/zone-verdict.uc
+++ b/root/usr/share/firewall4/templates/zone-verdict.uc
@@ -1,6 +1,5 @@
 {%+ if (rule.family): -%}
 	meta nfproto {{ fw4.nfproto(rule.family) }} {%+ endif -%}
-{%+ include("zone-match.uc", { egress, rule }) -%}
 {%+ if (zone.counter): -%}
 	counter {%+ endif -%}
 {%+ if (verdict != "accept" && (zone.log & 1)): -%}


### PR DESCRIPTION
Interface name list per zone is already filtered in basic chains then via jumps the arriving traffic is only that already filtered by interfaces.
Just dont emit 2nd {nterface list} @jow- 

Signed-Off-By: `Andris PE <neandris..gmail.com>`