### PR TITLE
rate-limit ICMP errors similar to kernel defaults

### DIFF
--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -194,6 +194,7 @@ table inet fw4 {
 				? `icmpx type ${fw4.default_option("tcp_reject_code")}`
 				: "tcp reset"
 		}} comment "!fw4: Reject TCP traffic"
+		limit rate over 1000/second burst 50 packets counter drop
 		reject with {{
 			(fw4.default_option("any_reject_code") != "tcp-reset")
 				? `icmpx type ${fw4.default_option("any_reject_code")}`


### PR DESCRIPTION
Rationale described here:
https://github.com/openwrt/openwrt/issues/13340#issuecomment-1693315898

UDP closed port will return 80 octets for 64 octets input at 1000/sec for each ip6/ip6 by kernel while nftable will have no limit. 
It is quick as in efficient approximation of more sophisticated linux kernel behaviour. Namely it does not implement 1 packet per address per timeslice on selected ICMP types.