### PR TITLE
Make conntrack checks in single rule

### DIFF
--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -100,10 +100,7 @@ table inet fw4 {
 		iifname "lo" accept comment "!fw4: Accept traffic from loopback"
 
 {% fw4.includes('chain-prepend', 'input') %}
-		ct state established,related accept comment "!fw4: Allow inbound established and related flows"
-{% if (fw4.default_option("drop_invalid")): %}
-		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
-{% endif %}
+		ct state vmap { established: accept, related:accept {% if (fw4.default_option("drop_invalid")): %} , invalid:drop {% endif -%} } comment "!fw4: Handle input flows"
 {% if (fw4.default_option("synflood_protect") && fw4.default_option("synflood_rate")): %}
 		tcp flags & (fin | syn | rst | ack) == syn jump syn_flood comment "!fw4: Rate limit TCP syn packets"
 {% endif %}
@@ -126,10 +123,7 @@ table inet fw4 {
 		meta l4proto { tcp, udp } flow offload @ft;
 {% endif %}
 {% fw4.includes('chain-prepend', 'forward') %}
-		ct state established,related accept comment "!fw4: Allow forwarded established and related flows"
-{% if (fw4.default_option("drop_invalid")): %}
-		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
-{% endif %}
+		ct state vmap { established: accept, related:accept {% if (fw4.default_option("drop_invalid")): %} , invalid:drop {% endif -%} } comment "!fw4: Handle forwarded flows"
 {% for (let rule in fw4.rules("forward")): %}
 		{%+ include("rule.uc", { fw4, rule }) %}
 {% endfor %}
@@ -148,10 +142,7 @@ table inet fw4 {
 		oifname "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 {% fw4.includes('chain-prepend', 'output') %}
-		ct state established,related accept comment "!fw4: Allow outbound established and related flows"
-{% if (fw4.default_option("drop_invalid")): %}
-		ct state invalid drop comment "!fw4: Drop flows with invalid conntrack state"
-{% endif %}
+		ct state vmap { established: accept, related:accept {% if (fw4.default_option("drop_invalid")): %} , invalid:drop {% endif -%} } comment "!fw4: Handle output flows"
 {% for (let rule in fw4.rules("output")): %}
 		{%+ include("rule.uc", { fw4, rule }) %}
 {% endfor %}


### PR DESCRIPTION
vmap of 2 states is faster than state,state, in addition handle 3rd state in same CPU time
reduces 10ms->9ms->7ms idle latency as measured at waveform on TL-WR1043NDv1 v22.03
Very steady measured at different day times.
@jow- ?

credits: `nft -o`

