### PR TITLE
WIP Stop spilling ICMP unreach to unrelated networks.

### DIFF
--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -189,6 +189,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		meta mark and 0x10000 ne 0x0 counter drop comment "!fw4: prevent rejects to mismatched interface"
 		meta l4proto tcp reject with {{
 			(fw4.default_option("tcp_reject_code") != "tcp-reset")
 				? `icmpx type ${fw4.default_option("tcp_reject_code")}`
@@ -405,6 +406,7 @@ table inet fw4 {
 	chain mangle_prerouting {
 		type filter hook prerouting priority mangle; policy accept;
 {% fw4.includes('chain-prepend', 'mangle_prerouting') %}
+		fib saddr . iif oif eq 0 counter meta mark set meta mark or 0x10000 comment "!fw4: mark packets on mismatched interface"
 {% for (let rule in fw4.rules("mangle_prerouting")): %}
 		{%+ include("rule.uc", { fw4, rule }) %}
 {% endfor %}


### PR DESCRIPTION
@jow- please tell if formatting should be this or cryptic readback from nft l r .. reject icmp enters stack via icmp_send, subject to routes and (permitted) output, thus 'drop' activity can be one line down, though i find no reason for it to send on wrong iface. Test: try to isolate network forwarding with reject. Misfeature dates back to iptables reject target incepticon. i know tests due, will adjust on feedback.
S-o-b: A P <n...m>