### PR TITLE
Do not emit extra drop invalid rule if drop invalid is already enacted in base table.

### DIFF
--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -269,7 +269,7 @@ table inet fw4 {
 {%   if (zone.dflags[verdict]): %}
 	chain {{ verdict }}_to_{{ zone.name }} {
 {%   for (let rule in zone.match_rules): %}
-{%     if (verdict == "accept" && (zone.masq || zone.masq6) && !zone.masq_allow_invalid): %}
+{%     if (!fw4.default_option("drop_invalid") && verdict == "accept" && (zone.masq || zone.masq6) && !zone.masq_allow_invalid): %}
 		{%+ include("zone-drop-invalid.uc", { fw4, zone, rule }) %}
 {%     endif %}
 		{%+ include("zone-verdict.uc", { fw4, zone, rule, egress: true, verdict }) %}


### PR DESCRIPTION
Completes: https://github.com/openwrt/firewall4/commit/119ee1a06d4a5e5fd01ec1a242d21d6f355d7ff6
Signed-off-by: `Andris PE <neandris..gmail.com>`

On 23.05 and snapshot the wan interface invalid+drop rule unnecessarily persists when invalid states is dropped globally and the rule cannot catch anything at all, so remove it as the effect is achieved by default and to global extent. @jow- 