### PR TITLE
Use symbolic ICMP types in MLD rule

### DIFF
--- a/root/etc/config/firewall
+++ b/root/etc/config/firewall
@@ -68,10 +68,10 @@ config rule
 	option src		wan
 	option proto		icmp
 	option src_ip		fe80::/10
-	list icmp_type		'130/0'
-	list icmp_type		'131/0'
-	list icmp_type		'132/0'
-	list icmp_type		'143/0'
+	list icmp_type		multicast-listener-query
+	list icmp_type		multicast-listener-report
+	list icmp_type		multicast-listener-done
+	list icmp_type		v2-multicast-listener-report
 	option family		ipv6
 	option target		ACCEPT
 


### PR DESCRIPTION
Symbolic ICMP types for MLD were added in commit e6e82a55206cf7017f26b92f7097f779161b5cac. This commit updates the config file to use them.