### PR TITLE
Reorder offload processing flow for earlier pickup

### DIFF
--- a/tests/01_configuration/01_ruleset
+++ b/tests/01_configuration/01_ruleset
@@ -122,8 +122,7 @@ table inet fw4 {
 	chain forward {
 		type filter hook forward priority filter; policy drop;
 
-		meta l4proto { tcp, udp } flow offload @ft;
-		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
+		ct state vmap { established : jump handle_offload, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "br-lan" jump forward_lan comment "!fw4: Handle lan IPv4/IPv6 forward traffic"
 		iifname "pppoe-wan" jump forward_wan comment "!fw4: Handle wan IPv4/IPv6 forward traffic"
 		jump handle_reject
@@ -148,6 +147,11 @@ table inet fw4 {
 	chain handle_reject {
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
+	}
+
+	chain handle_offload {
+		meta l4proto { tcp, udp } flow offload @ft
+		accept
 	}
 
 	chain syn_flood {


### PR DESCRIPTION
Do ct state dispatch before offload attempt on established states only.

Before:
- first data packet in connection commonly TLS client hello is attempted to be offloaded without assured ct status then follows slow path and response , normally tls server hello , offloads flow and follows the slow path again .
- It takes 2 slow paths to re-offload timer-retired or window-adjusted packets to re-enter offload table . 

After:
- ct status is marked as assured and packet is offloaded and response does not traverse slow path .
- Retired flow is adjusted by single packet and subsequent exchange offloaded skipping attempt to stuff them back in unmodified ct+offload table .
- ICMP (frag needed for example) reach related flow and offload happens on next TCP/UDP packet as before (minus the unnecessary match against udp in present path) .
- Less(er) minutely hickups in games and improved UDP VPN latency .

Signed-Off-By: Andris PE <neandris@gmail.com>
