### PR TITLE
Drop to-be-forwarded-nowhere packets on wans

### DIFF
--- a/root/etc/config/firewall
+++ b/root/etc/config/firewall
@@ -19,7 +19,7 @@ config zone
 	list   network		'wan6'
 	option input		REJECT
 	option output		ACCEPT
-	option forward		REJECT
+	option forward		DROP
 	option masq		1
 	option mtu_fix		1
 


### PR DESCRIPTION
Dropping packets with no clear forward destination is nicer than rejecting them. Especially when some providers punish users for spoofing caused by their noisy infra.

Fixes: https://github.com/openwrt/openwrt/issues/13340

Signed-Off-By: Andris PE <neandris@gmail.com>