### PR TITLE
Do not resolve physical devices for soft offload

### DIFF
--- a/root/usr/share/ucode/fw4.uc
+++ b/root/usr/share/ucode/fw4.uc
@@ -520,7 +520,11 @@ return {
 
 		for (let zone in this.zones())
 			for (let device in zone.related_physdevs)
-				push(devices, ...resolve_lower_devices(devstatus, device));
+				if (this.default_option("flow_offloading_hw")) {
+					push(devices, ...resolve_lower_devices(devstatus, device));
+				} else {
+					push(devices,device);
+				}
 		devices = sort(uniq(devices));
 
 		if (this.default_option("flow_offloading_hw")) {

--- a/root/usr/share/ucode/fw4.uc
+++ b/root/usr/share/ucode/fw4.uc
@@ -2049,9 +2049,6 @@ return {
 					});
 				}
 
-				if (net.physdev && !e.invert)
-					push(related_physdevs, net.physdev);
-
 				push(related_subnets, ...(net.ipaddrs || []));
 			}
 		}

--- a/root/usr/share/ucode/fw4.uc
+++ b/root/usr/share/ucode/fw4.uc
@@ -2049,6 +2049,9 @@ return {
 					});
 				}
 
+				if (net.physdev && !e.invert)
+					push(related_physdevs, net.physdev);
+
 				push(related_subnets, ...(net.ipaddrs || []));
 			}
 		}


### PR DESCRIPTION
Let kernel heuristics take care of offloading decapsulation Packets may still enter flow engine one encapsulation below actual interface subject to heuristics, while exiting it on listed interfaces, in kernel subject to non-flow encapsulation offloads.

Fixes: https://github.com/openwrt/openwrt/issues/13410
Fixes: https://github.com/openwrt/openwrt/issues/10224

This is minimally intrusive, to address issue, likely should be bitmask to selectively enable (forward interfaces|one encap below|virt interfaces|wifi|wifi not unique AP|probably others) or flaggs to +/- exact interface names to list.

Signed-off-by: Andris PE <neandris@gmail.com>