### PR TITLE
Do not add all physical devices for soft offload

### DIFF
--- a/root/usr/share/ucode/fw4.uc
+++ b/root/usr/share/ucode/fw4.uc
@@ -520,7 +520,11 @@ return {
 
 		for (let zone in this.zones())
 			for (let device in zone.related_physdevs)
-				push(devices, ...resolve_lower_devices(devstatus, device));
+				if (this.default_option("flow_offloading_hw")) {
+					push(devices, ...resolve_lower_devices(devstatus, device));
+				} else {
+					push(devices,device);
+				}
 		devices = sort(uniq(devices));
 
 		if (this.default_option("flow_offloading_hw")) {


### PR DESCRIPTION
Let kernel heuristics take care of offloading decapsulation Packets may still enter flow engine one encapsulation below actual interface subject to heuristics, while exiting it on listed interfaces, in kernel subject to non-flow encapsulation offloads.

Fixes: openwrt/openwrt#13410
Accidentally-part-fixes: openwrt/openwrt#10224

Signed-off-by: Andris PE <neandris@gmail.com>