### PR TITLE
ruleset: make synflood lighter using ct state

### DIFF
--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -117,7 +117,7 @@ table inet fw4 {
 {% fw4.includes('chain-prepend', 'input') %}
 		ct state vmap { established : accept, related : accept{% if (fw4.default_option("drop_invalid")): %}, invalid : drop{% endif %} } comment "!fw4: Handle inbound flows"
 {% if (fw4.default_option("synflood_protect") && fw4.default_option("synflood_rate")): %}
-		tcp flags & (fin | syn | rst | ack) == syn jump syn_flood comment "!fw4: Rate limit TCP syn packets"
+		ct state new meta l4proto tcp jump syn_flood comment "!fw4: Rate limit TCP syn packets"
 {% endif %}
 {% for (let rule in fw4.rules("input")): %}
 		{%+ include("rule.uc", { fw4, zone: null, rule }) %}

--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -116,6 +116,9 @@ table inet fw4 {
 
 {% fw4.includes('chain-prepend', 'input') %}
 		ct state vmap { established : accept, related : accept{% if (fw4.default_option("drop_invalid")): %}, invalid : drop{% endif %} } comment "!fw4: Handle inbound flows"
+{% if (fw4.default_option("synflood_protect") && fw4.default_option("synflood_rate")): %}
+		ct state new meta l4proto tcp jump syn_flood comment "!fw4: Rate limit TCP syn packets"
+{% endif %}
 {% for (let rule in fw4.rules("input")): %}
 		{%+ include("rule.uc", { fw4, zone: null, rule }) %}
 {% endfor %}
@@ -434,9 +437,6 @@ table inet fw4 {
 	chain mangle_input {
 		type filter hook input priority mangle; policy accept;
 {% fw4.includes('chain-prepend', 'mangle_input') %}
-{% if (fw4.default_option("synflood_protect") && fw4.default_option("synflood_rate")): %}
-		ct state new meta l4proto tcp jump syn_flood comment "!fw4: Rate limit TCP syn packets"
-{% endif %}
 {% for (let rule in fw4.rules("mangle_input")): %}
 		{%+ include("rule.uc", { fw4, zone: null, rule }) %}
 {% endfor %}

--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -116,9 +116,6 @@ table inet fw4 {
 
 {% fw4.includes('chain-prepend', 'input') %}
 		ct state vmap { established : accept, related : accept{% if (fw4.default_option("drop_invalid")): %}, invalid : drop{% endif %} } comment "!fw4: Handle inbound flows"
-{% if (fw4.default_option("synflood_protect") && fw4.default_option("synflood_rate")): %}
-		ct state new meta l4proto tcp jump syn_flood comment "!fw4: Rate limit TCP syn packets"
-{% endif %}
 {% for (let rule in fw4.rules("input")): %}
 		{%+ include("rule.uc", { fw4, zone: null, rule }) %}
 {% endfor %}
@@ -437,6 +434,9 @@ table inet fw4 {
 	chain mangle_input {
 		type filter hook input priority mangle; policy accept;
 {% fw4.includes('chain-prepend', 'mangle_input') %}
+{% if (fw4.default_option("synflood_protect") && fw4.default_option("synflood_rate")): %}
+		ct state new meta l4proto tcp jump syn_flood comment "!fw4: Rate limit TCP syn packets"
+{% endif %}
 {% for (let rule in fw4.rules("mangle_input")): %}
 		{%+ include("rule.uc", { fw4, zone: null, rule }) %}
 {% endfor %}

--- a/tests/01_configuration/01_ruleset
+++ b/tests/01_configuration/01_ruleset
@@ -113,7 +113,7 @@ table inet fw4 {
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
-		tcp flags & (fin | syn | rst | ack) == syn jump syn_flood comment "!fw4: Rate limit TCP syn packets"
+		ct state new meta l4proto tcp jump syn_flood comment "!fw4: Rate limit TCP syn packets"
 		iifname "br-lan" jump input_lan comment "!fw4: Handle lan IPv4/IPv6 input traffic"
 		iifname "pppoe-wan" jump input_wan comment "!fw4: Handle wan IPv4/IPv6 input traffic"
 		jump handle_reject

--- a/tests/01_configuration/01_ruleset
+++ b/tests/01_configuration/01_ruleset
@@ -113,7 +113,6 @@ table inet fw4 {
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
-		ct state new meta l4proto tcp jump syn_flood comment "!fw4: Rate limit TCP syn packets"
 		iifname "br-lan" jump input_lan comment "!fw4: Handle lan IPv4/IPv6 input traffic"
 		iifname "pppoe-wan" jump input_wan comment "!fw4: Handle wan IPv4/IPv6 input traffic"
 		jump handle_reject
@@ -274,6 +273,7 @@ table inet fw4 {
 
 	chain mangle_input {
 		type filter hook input priority mangle; policy accept;
+		ct state new meta l4proto tcp jump syn_flood comment "!fw4: Rate limit TCP syn packets"
 	}
 
 	chain mangle_output {

--- a/tests/01_configuration/01_ruleset
+++ b/tests/01_configuration/01_ruleset
@@ -113,6 +113,7 @@ table inet fw4 {
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
+		ct state new meta l4proto tcp jump syn_flood comment "!fw4: Rate limit TCP syn packets"
 		iifname "br-lan" jump input_lan comment "!fw4: Handle lan IPv4/IPv6 input traffic"
 		iifname "pppoe-wan" jump input_wan comment "!fw4: Handle wan IPv4/IPv6 input traffic"
 		jump handle_reject
@@ -273,7 +274,6 @@ table inet fw4 {
 
 	chain mangle_input {
 		type filter hook input priority mangle; policy accept;
-		ct state new meta l4proto tcp jump syn_flood comment "!fw4: Rate limit TCP syn packets"
 	}
 
 	chain mangle_output {


### PR DESCRIPTION
Make synflood inteject as found in default setup quicker by using ct state attribute and avoiding packet data examination.

Bytecode before:
```
// block A implicit
  [ meta load l4proto => reg 1 ]
  [ cmp eq reg 1 0x00000006 ]
// block B V1
  [ payload load 1b @ transport header + 13 => reg 1 ]
  [ bitwise reg 1 = ( reg 1 & 0x00000017 ) ^ 0x00000000 ]
  [ cmp eq reg 1 0x00000002 ]
// verdict
  [ immediate reg 0 jump -> syn_flood ]
```
After:
```
// block B V2
  [ ct load state => reg 1 ]
  [ bitwise reg 1 = ( reg 1 & 0x00000008 ) ^ 0x00000000 ]
  [ cmp neq reg 1 0x00000000 ]
// block A explicit
  [ meta load l4proto => reg 1 ]
  [ cmp eq reg 1 0x00000006 ]
// verdict
  [ immediate reg 0 jump -> syn_flood ]
```

Signed-Off-By: Andris PE <neandris@gmail.com>