### PR TITLE
fw4: when ipset matches MAC, allow set family to 'any'

### DIFF
--- a/root/usr/share/ucode/fw4.uc
+++ b/root/usr/share/ucode/fw4.uc
@@ -2571,7 +2571,7 @@ return {
 
 			/* check if there's no AF specific bits, in this case we can do an AF agnostic rule */
 			if (!family && rule.target != "dscp" && !has_ipv4_specifics && !has_ipv6_specifics) {
-				add_rule(0, proto, [], [], sports, dports, null, null, null, rule);
+				add_rule(0, proto, [], [], sports, dports, null, null, ipset, rule);
 			}
 
 			/* we need to emit one or two AF specific rules */
@@ -3305,11 +3305,7 @@ return {
 			return;
 		}
 
-		if (ipset.family == 0) {
-			this.warn_section(data, "must not specify family 'any'");
-			return;
-		}
-		else if (!length(ipset.match)) {
+		if (!length(ipset.match)) {
 			this.warn_section(data, "has no datatypes assigned");
 			return;
 		}
@@ -3317,6 +3313,11 @@ return {
 		let dirs = map(ipset.match, m => m[0]),
 		    types = map(ipset.match, m => m[1]),
 		    interval = false;
+
+		if (("ip" in types || "net" in types) && ipset.family == 0) {
+			this.warn_section(data, "must not specify family 'any' when matching type 'ip' or 'net'");
+			return;
+		}
 
 		if ("set" in types) {
 			this.warn_section(data, "match type 'set' is not supported");


### PR DESCRIPTION
When filtering by MAC address, it is usually necessary to filter both IPv4 and IPv6.
If it is not allowed to set the family of ipset to any, it will be necessary to create a separate, identical ipset for both IPv4 and IPv6.

Fixes: https://github.com/openwrt/firewall4/issues/16