### PR TITLE
[scripts] Remove unnecessary logic from stop script

### DIFF
--- a/root/sbin/fw4
+++ b/root/sbin/fw4
@@ -49,12 +49,9 @@ stop() {
 	{
 		flock -x 1000
 
-		if nft list tables inet | grep -sq "table inet fw4"; then
-			nft delete table inet fw4
-			rm -f $STATE
-		else
-			return 1
-		fi
+		nft delete table inet fw4
+		rm -f $STATE
+
 	} 1000>$LOCK
 }
 


### PR DESCRIPTION
Always remove table and service state to have consistent cleaned up system state on exit even if user intentionally dropped our table. Removes dependency on grep as a consequence.

Ref: https://wiki.nftables.org/wiki-nftables/index.php/Configuring_tables
Supersedes: https://github.com/openwrt/firewall4/pull/33

Signed-off-by: Andris PE <neandris@gmail.com>