### PR TITLE
Limit mss fixup to connection start

### DIFF
--- a/root/usr/share/firewall4/templates/zone-mssfix.uc
+++ b/root/usr/share/firewall4/templates/zone-mssfix.uc
@@ -1,3 +1,4 @@
+ct packets < 14 {%+ -%}
 {%+ if (rule.family): -%}
 	meta nfproto {{ fw4.nfproto(rule.family) }} {%+ endif -%}
 {%+ include("zone-match.uc", { egress, rule }) -%}

--- a/tests/01_configuration/01_ruleset
+++ b/tests/01_configuration/01_ruleset
@@ -269,7 +269,7 @@ table inet fw4 {
 
 	chain mangle_postrouting {
 		type filter hook postrouting priority mangle; policy accept;
-		oifname "pppoe-wan" tcp flags syn / syn,fin,rst tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4/IPv6 egress MTU fixing"
+		ct packets < 14 oifname "pppoe-wan" tcp flags syn / syn,fin,rst tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4/IPv6 egress MTU fixing"
 	}
 
 	chain mangle_input {
@@ -282,7 +282,7 @@ table inet fw4 {
 
 	chain mangle_forward {
 		type filter hook forward priority mangle; policy accept;
-		iifname "pppoe-wan" tcp flags syn / syn,fin,rst tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4/IPv6 ingress MTU fixing"
+		ct packets < 14 iifname "pppoe-wan" tcp flags syn / syn,fin,rst tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4/IPv6 ingress MTU fixing"
 	}
 }
 -- End --


### PR DESCRIPTION
Use conntrack flow packet counter to limit mss fixup filter to the very start of connection flows where adjustable syn/syn can possibly appear.

Two initial packets +
> sysctl net.ipv4.tcp_syn_retries net.ipv4.tcp_synack_retries
net.ipv4.tcp_syn_retries = 6
net.ipv4.tcp_synack_retries = 5

Signed-off-by: Andris PE <neandris@gmail.com>