### PR TITLE
fw4: do not allow setting ports for non-TCP or -UDP rules and redirects

### DIFF
--- a/root/usr/share/ucode/fw4.uc
+++ b/root/usr/share/ucode/fw4.uc
@@ -2375,6 +2375,11 @@ return {
 			return;
 		}
 
+		if ((rule.src_port || rule.dest_port) && !ensure_tcpudp(rule.proto)) {
+			this.warn_section(data, "specifies ports but no UDP/TCP protocol, ignoring section");
+			return;
+		}
+
 		switch (this.parse_bool(rule.log)) {
 		case true:
 			rule.log = `${rule.name}: `;
@@ -2668,6 +2673,11 @@ return {
 		}
 		else if (!redir.enabled) {
 			this.warn_section(data, "is disabled, ignoring section");
+			return;
+		}
+
+		if ((redir.src_port || redir.src_dport || redir.dest_port) && !ensure_tcpudp(redir.proto)) {
+			this.warn_section(data, "specifies ports but no UDP/TCP protocol, ignoring section");
 			return;
 		}
 


### PR DESCRIPTION
Currently, it is possible to set source and destination ports for `proto` like `all` or `icmp`, although only `tcp` and `udp` ports are converted into the `nftables` ruleset.

While this might not be a problem for a protocol like `ICMP`, there is a security risk when the user specifies `all`, because then the rule/redirect applies to all L4 ports, including `TCP` and `UDP`, regardless if the user sets specific ports.

This commit checks for rules and redirects that if any port was set the protocol must be `TCP` and/or `UDP`. If not, the user will be informed via a warning, and the rule/redirect won't be applied. Should the protocol be `all`, it is automatically corrected
to `TCP` and `UDP` by the `ucode` function `ensure_tcpudp`.

Here are two examples for an input and a DNAT rule:
<pre>
config rule
        option name             'Rule-Test'
        option src              'wan'
        option dest_port        '22'
        option proto            'all'
        option target           'ACCEPT'

config redirect
        option name             'DNAT-Test'
        option src              'wan'
        option src_dport        '22222'
        option dest             'lan'
        option dest_ip          '192.168.1.2'
        option dest_port        '22'
        option proto            'all'
        option target           'DNAT'
</pre>
<br>

Resulting into the following `nftables` rules:
<pre>
chain input_wan {
	counter packets 0 bytes 0 accept comment "!fw4: Rule-Test"
	ct status dnat accept comment "!fw4: Accept port redirections"
	jump reject_from_wan
}

chain dstnat_wan {
	meta nfproto ipv4 counter packets 0 bytes 0 dnat ip to 192.168.1.2 comment "!fw4: DNAT-Test"
}
</pre>
<br>

The input rule ignores the destination port and, therefore, accepts any incoming traffic, while the DNAT rule redirects any IPv4 traffic to the given destination IP `192.168.1.2`, ignoring any port settings.