### PR TITLE
config: Drop unaccounted icmp6 packets

### DIFF
--- a/root/etc/config/firewall
+++ b/root/etc/config/firewall
@@ -81,7 +81,7 @@ config rule
 	option src		wan
 	option proto	icmp
 	list icmp_type		echo-request
-	list icmp_type		echo-reply
+	# list icmp_type		echo-reply
 	list icmp_type		destination-unreachable
 	list icmp_type		packet-too-big
 	list icmp_type		time-exceeded
@@ -91,9 +91,17 @@ config rule
 	list icmp_type		neighbour-solicitation
 	list icmp_type		router-advertisement
 	list icmp_type		neighbour-advertisement
+	# list icmo_type		fragmentation-needed
 	option limit		1000/sec
 	option family		ipv6
 	option target		ACCEPT
+
+config rule
+	option name		Drop-ICMPv6-Excess
+	option src		wan
+	option proto		icmp
+	option family		ipv6
+	option target		DROP
 
 # Allow essential forwarded IPv6 ICMP traffic
 config rule
@@ -102,15 +110,24 @@ config rule
 	option dest		*
 	option proto		icmp
 	list icmp_type		echo-request
-	list icmp_type		echo-reply
+	# list icmp_type		echo-reply
 	list icmp_type		destination-unreachable
 	list icmp_type		packet-too-big
 	list icmp_type		time-exceeded
 	list icmp_type		bad-header
 	list icmp_type		unknown-header-type
+	# list icmo_type		fragmentation-needed
 	option limit		1000/sec
 	option family		ipv6
 	option target		ACCEPT
+
+config rule
+	option name		Drop-ICMPv6-Forward-Excess
+	option sec		wan
+	option dest		*
+	option proto		icmp
+	option family		ipv6
+	option target		DROP
 
 config rule
 	option name		Allow-IPSec-ESP

--- a/root/etc/config/firewall
+++ b/root/etc/config/firewall
@@ -81,7 +81,6 @@ config rule
 	option src		wan
 	option proto	icmp
 	list icmp_type		echo-request
-	# list icmp_type		echo-reply
 	list icmp_type		destination-unreachable
 	list icmp_type		packet-too-big
 	list icmp_type		time-exceeded
@@ -91,7 +90,6 @@ config rule
 	list icmp_type		neighbour-solicitation
 	list icmp_type		router-advertisement
 	list icmp_type		neighbour-advertisement
-	# list icmo_type		fragmentation-needed
 	option limit		1000/sec
 	option family		ipv6
 	option target		ACCEPT
@@ -110,20 +108,16 @@ config rule
 	option dest		*
 	option proto		icmp
 	list icmp_type		echo-request
-	# list icmp_type		echo-reply
-	list icmp_type		destination-unreachable
-	list icmp_type		packet-too-big
 	list icmp_type		time-exceeded
 	list icmp_type		bad-header
 	list icmp_type		unknown-header-type
-	# list icmo_type		fragmentation-needed
 	option limit		1000/sec
 	option family		ipv6
 	option target		ACCEPT
 
 config rule
 	option name		Drop-ICMPv6-Forward-Excess
-	option sec		wan
+	option src		wan
 	option dest		*
 	option proto		icmp
 	option family		ipv6


### PR DESCRIPTION
Drop ICMPv6 packets that are not explicitly allowed, like falling outside conntrack due to missing embedded state header like in referenced issue

Add older patch and omit singular echo reply as it is traditionally seen only in conntrack state only initiated by echo request.

implement rfc6092 REC-10

Fixes: https://github.com/openwrt/openwrt/issues/17800
Supersedes: https://github.com/openwrt/openwrt/pull/17805
Supersedes: https://github.com/openwrt/firewall4/pull/38
Signed-off-by: Andris PE <neandris@gmail.com>
Fixes: https://github.com/openwrt/openwrt/issues/21549