### PR TITLE
ruleset: do not reject invalid (out of state) packets

### DIFF
--- a/root/usr/share/firewall4/templates/zone-verdict.uc
+++ b/root/usr/share/firewall4/templates/zone-verdict.uc
@@ -10,7 +10,7 @@
 {%+  if (verdict != "accept" && (zone.log & 1)): -%}
 	log prefix "{{ verdict }} {{ zone.name }} {{ egress ? "out" : "in" }}: " {%+ endif -%}
 {%   if (verdict == "reject"): -%}
-	jump handle_reject comment "!fw4: reject {{ zone.name }} {{ fw4.nfproto(rule.family, true) }} traffic"
+	goto handle_reject comment "!fw4: reject {{ zone.name }} {{ fw4.nfproto(rule.family, true) }} traffic"
 {%   else -%}
 	{{ verdict }} comment "!fw4: {{ verdict }} {{ zone.name }} {{ fw4.nfproto(rule.family, true) }} traffic"
 {%   endif -%}

--- a/tests/01_configuration/01_ruleset
+++ b/tests/01_configuration/01_ruleset
@@ -116,7 +116,7 @@ table inet fw4 {
 		tcp flags & (fin | syn | rst | ack) == syn jump syn_flood comment "!fw4: Rate limit TCP syn packets"
 		iifname "br-lan" jump input_lan comment "!fw4: Handle lan IPv4/IPv6 input traffic"
 		iifname "pppoe-wan" jump input_wan comment "!fw4: Handle wan IPv4/IPv6 input traffic"
-		jump handle_reject
+		goto handle_reject
 	}
 
 	chain forward {
@@ -126,7 +126,7 @@ table inet fw4 {
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "br-lan" jump forward_lan comment "!fw4: Handle lan IPv4/IPv6 forward traffic"
 		iifname "pppoe-wan" jump forward_wan comment "!fw4: Handle wan IPv4/IPv6 forward traffic"
-		jump handle_reject
+		goto handle_reject
 	}
 
 	chain output {
@@ -146,6 +146,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}
@@ -220,11 +221,11 @@ table inet fw4 {
 	}
 
 	chain reject_from_wan {
-		iifname "pppoe-wan" counter jump handle_reject comment "!fw4: reject wan IPv4/IPv6 traffic"
+		iifname "pppoe-wan" counter goto handle_reject comment "!fw4: reject wan IPv4/IPv6 traffic"
 	}
 
 	chain reject_to_wan {
-		oifname "pppoe-wan" counter jump handle_reject comment "!fw4: reject wan IPv4/IPv6 traffic"
+		oifname "pppoe-wan" counter goto handle_reject comment "!fw4: reject wan IPv4/IPv6 traffic"
 	}
 
 

--- a/tests/01_configuration/02_rule_order
+++ b/tests/01_configuration/02_rule_order
@@ -121,6 +121,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/02_zones/01_policies
+++ b/tests/02_zones/01_policies
@@ -129,6 +129,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}
@@ -195,11 +196,11 @@ table inet fw4 {
 	}
 
 	chain reject_from_test3 {
-		iifname "zone3" counter jump handle_reject comment "!fw4: reject test3 IPv4/IPv6 traffic"
+		iifname "zone3" counter goto handle_reject comment "!fw4: reject test3 IPv4/IPv6 traffic"
 	}
 
 	chain reject_to_test3 {
-		oifname "zone3" counter jump handle_reject comment "!fw4: reject test3 IPv4/IPv6 traffic"
+		oifname "zone3" counter goto handle_reject comment "!fw4: reject test3 IPv4/IPv6 traffic"
 	}
 
 

--- a/tests/02_zones/02_masq
+++ b/tests/02_zones/02_masq
@@ -130,6 +130,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}
@@ -188,11 +189,11 @@ table inet fw4 {
 	}
 
 	chain reject_from_test3 {
-		iifname "zone3" counter jump handle_reject comment "!fw4: reject test3 IPv4/IPv6 traffic"
+		iifname "zone3" counter goto handle_reject comment "!fw4: reject test3 IPv4/IPv6 traffic"
 	}
 
 	chain reject_to_test3 {
-		oifname "zone3" counter jump handle_reject comment "!fw4: reject test3 IPv4/IPv6 traffic"
+		oifname "zone3" counter goto handle_reject comment "!fw4: reject test3 IPv4/IPv6 traffic"
 	}
 
 

--- a/tests/02_zones/03_masq_src_dest_restrictions
+++ b/tests/02_zones/03_masq_src_dest_restrictions
@@ -150,6 +150,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/02_zones/04_masq_allow_invalid
+++ b/tests/02_zones/04_masq_allow_invalid
@@ -96,6 +96,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/02_zones/04_wildcard_devices
+++ b/tests/02_zones/04_wildcard_devices
@@ -179,6 +179,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/02_zones/05_subnet_mask_matches
+++ b/tests/02_zones/05_subnet_mask_matches
@@ -118,6 +118,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/02_zones/06_family_selections
+++ b/tests/02_zones/06_family_selections
@@ -177,6 +177,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/02_zones/07_helpers
+++ b/tests/02_zones/07_helpers
@@ -206,6 +206,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/02_zones/08_log_limit
+++ b/tests/02_zones/08_log_limit
@@ -281,6 +281,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/03_rules/01_direction
+++ b/tests/03_rules/01_direction
@@ -97,6 +97,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/03_rules/02_enabled
+++ b/tests/03_rules/02_enabled
@@ -92,6 +92,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/03_rules/03_constraints
+++ b/tests/03_rules/03_constraints
@@ -131,6 +131,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/03_rules/04_icmp
+++ b/tests/03_rules/04_icmp
@@ -104,6 +104,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/03_rules/05_mangle
+++ b/tests/03_rules/05_mangle
@@ -208,6 +208,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/03_rules/06_subnet_mask_matches
+++ b/tests/03_rules/06_subnet_mask_matches
@@ -175,6 +175,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/03_rules/07_redirect
+++ b/tests/03_rules/07_redirect
@@ -196,6 +196,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/03_rules/08_family_inheritance
+++ b/tests/03_rules/08_family_inheritance
@@ -227,6 +227,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/03_rules/09_time
+++ b/tests/03_rules/09_time
@@ -173,6 +173,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/03_rules/10_notrack
+++ b/tests/03_rules/10_notrack
@@ -137,6 +137,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/03_rules/11_log
+++ b/tests/03_rules/11_log
@@ -139,6 +139,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/03_rules/12_mark
+++ b/tests/03_rules/12_mark
@@ -120,6 +120,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/04_forwardings/01_family_selections
+++ b/tests/04_forwardings/01_family_selections
@@ -123,6 +123,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/05_ipsets/01_declaration
+++ b/tests/05_ipsets/01_declaration
@@ -110,6 +110,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/05_ipsets/02_usage
+++ b/tests/05_ipsets/02_usage
@@ -190,6 +190,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/06_includes/01_nft_includes
+++ b/tests/06_includes/01_nft_includes
@@ -183,6 +183,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/06_includes/02_firewall.user_include
+++ b/tests/06_includes/02_firewall.user_include
@@ -118,6 +118,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/06_includes/04_disabled_include
+++ b/tests/06_includes/04_disabled_include
@@ -124,6 +124,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}

--- a/tests/06_includes/05_automatic_includes
+++ b/tests/06_includes/05_automatic_includes
@@ -124,6 +124,7 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+		ct state invalid counter drop comment "!fw4: drop invalid packets before reject"
 		meta l4proto tcp reject with tcp reset comment "!fw4: Reject TCP traffic"
 		reject with icmpx type port-unreachable comment "!fw4: Reject any other traffic"
 	}


### PR DESCRIPTION
We cannot fix invalid (checksum, out of state, short) packets by replying them with valid packet. Lets keep grief to bare minimum.

Part-fixes: https://github.com/openwrt/openwrt/issues/13340
(the "new" valid packets would have been replied with spoofed packet but those should have been relatively rare to make problem less noticeable)

Changes jump to goto - there is no "next" rule to reach after connection is reset and forgotten.

Signed-off-by: Andris PE <neandris@gmail.com>