### PR TITLE
[ruleset] Relocate ruleset-prepend include before our table

### DIFF
--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -5,12 +5,12 @@
 	let zones_with_limits = filter(fw4.zones(), z => z.log_limit);
 -%}
 
+{% fw4.includes('ruleset-prepend') %}
 table inet fw4
 flush table inet fw4
 {% if (fw4.check_flowtable()): %}
 delete flowtable inet fw4 ft
 {% endif %}
-{% fw4.includes('ruleset-prepend') %}
 
 table inet fw4 {
 {% if (length(flowtable_devices) > 0): %}

--- a/tests/06_includes/01_nft_includes
+++ b/tests/06_includes/01_nft_includes
@@ -124,10 +124,10 @@ Testing the correct placement of potential include positions.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
 
 include "/usr/share/nftables.d/include-ruleset-start.nft"
+table inet fw4
+flush table inet fw4
 
 table inet fw4 {
 	#


### PR DESCRIPTION
Issue described in https://github.com/openwrt/firewall4/issues/51 and fix proposed by @somerandomname

Fixes: https://github.com/openwrt/firewall4/issues/51
Fixes: https://github.com/openwrt/firewall4/commit/11256ff0374fb594e31b0a4e3857f3810ba2933d

Signed-off-by: Andris PE <neandris@gmail.com>