### PR TITLE
fw4: fix reading kernel version

### DIFF
--- a/root/usr/share/ucode/fw4.uc
+++ b/root/usr/share/ucode/fw4.uc
@@ -496,9 +496,9 @@ return {
 		    v = 0;
 
 		if (fd) {
-		    let m = match(fd.read("line"), /^Linux version ([0-9]+)\.([0-9]+)\.([0-9]+)/);
+		    let m = match(fd.read("line"), /^Linux version ([0-9]+)\.([0-9]+)(\.([0-9]+))?/);
 
-		    v = m ? (+m[1] << 24) | (+m[2] << 16) | (+m[3] << 8) : 0;
+		    v = m ? (+m[1] << 24) | (+m[2] << 16) | (+m[4]) : 0;
 		    fd.close();
 		}
 


### PR DESCRIPTION
Fix reading kernel version for kernels with revision 0 e.g. 6.12
Repair incorrect shift of the revision number causing incorrect value for > 255.

Cherry-picked from commit 086a02727695da7da2580af4268f2b968bd83c6e