### PR TITLE
scripts: restore fw3 ct flush behavior

### DIFF
--- a/root/sbin/fw4
+++ b/root/sbin/fw4
@@ -60,11 +60,9 @@ flush() {
 	{
 		flock -x 1000
 
-		local dummy family table
-		nft list tables | while read dummy family table; do
-			nft delete table "$family" "$table"
-		done
-
+		nft add table inet fw4
+		nft delete table inet fw4
+		echo f > /proc/net/nf_conntrack
 		rm -f $STATE
 	} 1000>$LOCK
 }

--- a/root/sbin/fw4
+++ b/root/sbin/fw4
@@ -37,6 +37,7 @@ start() {
 
 		ACTION=includes \
 			utpl -S $MAIN
+		[ -n "$CTFLUSH" ] && echo f > /proc/net/nf_conntrack
 	} 1000>$LOCK
 }
 
@@ -95,7 +96,11 @@ while [ -n "$1" ]; do
 done
 
 case "$1" in
-	start|reload)
+	start)
+		nft 'create table inet fw4' 2>/dev/null && export CTFLUSH=1
+		start "$1"
+	;;
+	reload)
 		start "$1"
 	;;
 	stop)


### PR DESCRIPTION
Flush conntrack if fw4 is started with fw4 table absent
Approximates fw3 ct flush when no iptables rules are present
Prevents (deletes) eternal ghost states created at early boot.
Also treat flush action called stopping the service, emulate 'destroy table' to to stay v23 compatible

Signed-off-by: Andris PE <neandris@gmail.com>