### PR TITLE
config: Make DHCP and DHCPv6 response rules strict

### DIFF
--- a/root/etc/config/firewall
+++ b/root/etc/config/firewall
@@ -33,8 +33,17 @@ config rule
 	option name		Allow-DHCP-Renew
 	option src		wan
 	option proto		udp
+	option src_port		67
 	option dest_port	68
 	option target		ACCEPT
+	option family		ipv4
+
+config rule
+	option name		Drop-DHCP-Unsolicited
+	option src		wan
+	option proto		udp
+	option dst_port		68
+	option target		DROP
 	option family		ipv4
 
 # Allow IPv4 ping
@@ -59,9 +68,18 @@ config rule
 	option name		Allow-DHCPv6
 	option src		wan
 	option proto		udp
+	option src_port		547
 	option dest_port	546
 	option family		ipv6
 	option target		ACCEPT
+
+config rule
+	option name		Drop-DHCPv6-Unsolicited
+	option src		wan
+	option proto		udp
+	option dest_port	546
+	option family		ipv6
+	option target		DROP
 
 config rule
 	option name		Allow-MLD


### PR DESCRIPTION
Non-server DHCPx responses indicated by non-standard sport are already discarded by client, reflect that in firewall rule avoiding unnecessary ct state buildup wasting ct resources

Signed-off-by: Andris PE <neandris@gmail.com>