### PR TITLE
config: strict ip6 ipsec matches

### DIFF
--- a/root/etc/config/firewall
+++ b/root/etc/config/firewall
@@ -113,20 +113,31 @@ config rule
 	option target		ACCEPT
 
 config rule
-	option name		Allow-IPSec-ESP
+	option name		Allow-IPv6-IPSec-ESP
 	option src		wan
 	option dest		lan
 	option proto		esp
+	option family		ipv6
 	option target		ACCEPT
 
 config rule
-	option name		Allow-ISAKMP
+	option name		Allow-IPv6-IKE
+	option src		wan
+	option dest		lan
+	option src_port		500
+	option dest_port	500
+	option proto		udp
+	option family		ipv6
+	option target		ACCEPT
+
+config rule
+	option name		Drop-IPv6-IKE-Unsolicited
 	option src		wan
 	option dest		lan
 	option dest_port	500
 	option proto		udp
-	option target		ACCEPT
-
+	option family		ipv6
+	option target		DROP
 
 ### EXAMPLE CONFIG SECTIONS
 # do not allow a specific ip to access wan


### PR DESCRIPTION
ip4 part never served any purpose except confusing users eg https://github.com/openwrt/firewall4/issues/53
Permit only IKE conformant to RFC, ip4 NAT traversal has different port and terminating on the router can be handled by ipsec policy filtering.

Fixes: https://github.com/openwrt/openwrt/commit/8fb39f168249f15697ab930245ad08ea66a1b926

Signed-off-by: Andris PE <neandris@gmail.com>
