### PR TITLE
scripts: work around nftables 1.1.3 tz calc bug

### DIFF
--- a/root/sbin/fw4
+++ b/root/sbin/fw4
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -o pipefail
+export TZ=Z
 
 MAIN=/usr/share/firewall4/main.uc
 LOCK=/var/run/fw4.lock


### PR DESCRIPTION
bool utc_time is not implemented, so all calculations and indications pertain UTC0 timezone only.
More detail in upstream report, probably this becomes obsolete with next nftables revision.

Reported-by: @thess
Ref: https://bugzilla.netfilter.org/show_bug.cgi?id=1805
Fixes: https://github.com/openwrt/openwrt/issues/19482

Signed-off-by: Andris PE <neandris@gmail.com>