### PR TITLE
ruleset: fix for missing counters handling code for ipsets

### DIFF
--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -61,6 +61,9 @@ table inet fw4 {
 {%   if (set.timeout > 0): %}
 		timeout {{ set.timeout }}s
 {%   endif %}
+{%   if (set.counters): %}
+		counter
+{%   endif %}
 {%   if (set.interval): %}
 		auto-merge
 {%   endif %}

--- a/tests/05_ipsets/01_declaration
+++ b/tests/05_ipsets/01_declaration
@@ -57,6 +57,7 @@ table inet fw4 {
 		type ipv4_addr . inet_service
 		size 1000
 		timeout 600s
+		counter
 		flags timeout
 		elements = {
 			1.2.3.4 . 80,


### PR DESCRIPTION
Added missing code for handling ipset counters mentioned in this [issue](https://github.com/openwrt/firewall4/issues/69)