### PR TITLE
ruleset: avoid no-op port translation in dnat

### DIFF
--- a/root/etc/config/firewall
+++ b/root/etc/config/firewall
@@ -155,7 +155,6 @@ config rule
 #	option src_dport	80
 #	option dest			lan
 #	option dest_ip		192.168.16.235
-#	option dest_port	80
 #	option proto		tcp
 
 # port redirect of remapped ssh port (22001) on wan

--- a/root/usr/share/ucode/fw4.uc
+++ b/root/usr/share/ucode/fw4.uc
@@ -2740,9 +2740,6 @@ return {
 			if (!redir.dest && redir.dest_ip && resolve_dest(redir))
 				this.warn_section(data, `does not specify a destination, assuming '${redir.dest.zone.name}'`);
 
-			if (!redir.dest_port)
-				redir.dest_port = redir.src_dport;
-
 			if (redir.reflection && redir.dest?.zone && redir.src.zone.masq) {
 				redir.dest.zone.dflags.accept = true;
 				redir.dest.zone.dflags.dnat = true;
@@ -2976,7 +2973,7 @@ return {
 
 								for (let daddrs in subnets_group_by_masking(rip[i]))
 									for (let saddrs in subnets_group_by_masking(iaddrs[i]))
-										add_rule(i ? 6 : 4, proto, saddrs, daddrs, [ to_hostaddr(snat_addr) ], null, rport, null, null, refredir);
+										add_rule(i ? 6 : 4, proto, saddrs, daddrs, [ to_hostaddr(snat_addr) ], null, rport ? rport : dport, null, null, refredir);
 							}
 						}
 					}

--- a/tests/03_rules/07_redirect
+++ b/tests/03_rules/07_redirect
@@ -75,6 +75,7 @@ Test various address selection rules in redirect rules.
 			"proto": "tcp",
 			"src_dport": "23",
 			"dest_ip": "192.168.26.100",
+			"dest_port": "23",
 			"reflection_src": "external"
 		},
 		{
@@ -117,7 +118,17 @@ Test various address selection rules in redirect rules.
 			"dest": "lan",
 			"proto": "tcp",
 			"src_dport": "27",
-			"dest_port": "27",
+			"target": "dnat"
+		},
+		{
+			".description": "Ensure inverse address match works properly",
+			"name": "Redirect test #9",
+			"src": "lan",
+			"dest": "wan",
+			"proto": "tcp udp",
+			"src_dport": "53",
+			"dest_ip": "192.168.1.53",
+			"src_ip": "!192.168.1.53",
 			"target": "dnat"
 		}
 	]
@@ -290,11 +301,11 @@ table inet fw4 {
 	}
 
 	chain dstnat_wan {
-		meta nfproto ipv4 tcp dport 22 counter dnat 192.168.26.100:22 comment "!fw4: Redirect test #3"
+		meta nfproto ipv4 tcp dport 22 counter dnat 192.168.26.100 comment "!fw4: Redirect test #3"
 		meta nfproto ipv4 tcp dport 23 counter dnat 192.168.26.100:23 comment "!fw4: Redirect test #4"
 		meta nfproto ipv6 tcp dport 25 counter dnat [2001:db8:1000:1::1234]:25 comment "!fw4: Redirect test #6"
 		meta nfproto ipv4 tcp dport 26 counter redirect to 26 comment "!fw4: Redirect test #7"
-		meta nfproto ipv6 tcp dport 27 counter redirect to 27 comment "!fw4: Redirect test #8"
+		meta nfproto ipv6 tcp dport 27 counter redirect comment "!fw4: Redirect test #8"
 	}
 
 	chain srcnat_wan {
@@ -305,9 +316,11 @@ table inet fw4 {
 	chain dstnat_lan {
 		meta nfproto ipv4 udp dport 53 counter redirect to 53 comment "!fw4: Redirect test #1"
 		udp dport 53 counter redirect to 53 comment "!fw4: Redirect test #2"
-		ip saddr { 10.0.0.0/24, 192.168.26.0/24 } ip daddr 10.11.12.194 tcp dport 22 dnat 192.168.26.100:22 comment "!fw4: Redirect test #3 (reflection)"
+		ip saddr { 10.0.0.0/24, 192.168.26.0/24 } ip daddr 10.11.12.194 tcp dport 22 dnat 192.168.26.100 comment "!fw4: Redirect test #3 (reflection)"
 		ip saddr { 10.0.0.0/24, 192.168.26.0/24 } ip daddr 10.11.12.194 tcp dport 23 dnat 192.168.26.100:23 comment "!fw4: Redirect test #4 (reflection)"
 		ip6 saddr { 2001:db8:1000::/60, fd63:e2f:f706::/60 } ip6 daddr 2001:db8:54:321::2 tcp dport 25 dnat [2001:db8:1000:1::1234]:25 comment "!fw4: Redirect test #6 (reflection)"
+		ip saddr != 192.168.1.53 tcp dport 53 counter dnat 192.168.1.53 comment "!fw4: Redirect test #9"
+		ip saddr != 192.168.1.53 udp dport 53 counter dnat 192.168.1.53 comment "!fw4: Redirect test #9"
 	}
 
 	chain srcnat_lan {
@@ -317,7 +330,7 @@ table inet fw4 {
 	}
 
 	chain dstnat_noaddr {
-		meta nfproto ipv4 tcp dport 24 counter dnat 192.168.26.100:24 comment "!fw4: Redirect test #5"
+		meta nfproto ipv4 tcp dport 24 counter dnat 192.168.26.100 comment "!fw4: Redirect test #5"
 	}
 
 	chain srcnat_noaddr {


### PR DESCRIPTION
Correct rport null propagation moving compensatory conditional to reflection snat rule only.
Emit shorthand rules if user did not specify redirect target port
This saves 2 bytecodes in rule and kernel does not do no-op port rewrite.
Also tweak tests to cover changed rules. 
V2 add test case from WIKI https://openwrt.org/docs/guide-user/firewall/fw3_configurations/intercept_dns#dns_redirection
V3 omit unchanged dport in config example