### PR TITLE
ruleset: Add snat_port support for MASQUERADE

### DIFF
--- a/root/usr/share/firewall4/templates/redirect.uc
+++ b/root/usr/share/firewall4/templates/redirect.uc
@@ -74,8 +74,10 @@
 	log prefix {{ fw4.quote(redirect.log, true) }} {%+ endif -%}
 {%   if (redirect.target == "redirect"): -%}
 	redirect{% if (redirect.rport): %} to {{ fw4.port(redirect.rport) }}{% endif %}
-{%-  elif (redirect.target == "accept" || redirect.target == "masquerade"): -%}
+{%-  elif (redirect.target == "accept"): -%}
 	{{ redirect.target }}
+{%-  elif (redirect.target == "masquerade"): -%}
+	{{ redirect.target }}{% if (redirect.rport): %} to :{{ fw4.port(redirect.rport) }}{% endif %}
 {%-  else -%}
 	{{ redirect.target }} {{ redirect.raddr ? fw4.host(redirect.raddr, redirect.rport != null) : '' }}
 	{%- if (redirect.rport): %}:{{ fw4.port(redirect.rport) }}{% endif %}

--- a/root/usr/share/ucode/fw4.uc
+++ b/root/usr/share/ucode/fw4.uc
@@ -3084,8 +3084,8 @@ return {
 			this.warn_section(data, "must not use 'snat_ip' for non-snat target, ignoring section");
 			return;
 		}
-		else if (snat.target != "snat" && snat.snat_port) {
-			this.warn_section(data, "must not use 'snat_port' for non-snat target, ignoring section");
+		else if (snat.target != "snat" && snat.target != "masquerade" && snat.snat_port) {
+			this.warn_section(data, "must not use 'snat_port' for non-snat or non-masquerade target, ignoring section");
 			return;
 		}
 

--- a/tests/03_rules/07_redirect
+++ b/tests/03_rules/07_redirect
@@ -120,6 +120,17 @@ Test various address selection rules in redirect rules.
 			"dest_port": "27",
 			"target": "dnat"
 		}
+	],
+	"nat": [
+		{
+			".description": "Ensure that masq to specific port or port range rules work properly",
+			"name": "masq snat test #1",
+			"family": "ipv4",
+			"src": "wan",
+			"proto": "tcp udp",
+			"snat_port": "61000-62900",
+			"target": "MASQUERADE"
+		}
 	]
 }
 -- End --
@@ -298,6 +309,8 @@ table inet fw4 {
 	}
 
 	chain srcnat_wan {
+		meta nfproto ipv4 meta l4proto tcp counter masquerade to :61000-62900 comment "!fw4: masq snat test #1"
+		meta nfproto ipv4 meta l4proto udp counter masquerade to :61000-62900 comment "!fw4: masq snat test #1"
 		meta nfproto ipv4 masquerade comment "!fw4: Masquerade IPv4 wan traffic"
 		meta nfproto ipv6 masquerade comment "!fw4: Masquerade IPv6 wan traffic"
 	}


### PR DESCRIPTION
In a NAT444 dynamic IP environment where the ISP's BRAS uses Full-Cone NAT, limiting the MASQUERADE port range on OpenWrt can help prevent the number of sessions on the BRAS side from exceeding the limit. However, currently, if snat_port is configured in OpenWrt's NAT rules, the MASQUERADE rule fails to generate and produces an error. This modification ensures that MASQUERADE rules are correctly generated even when snat_port is specified.