### PR TITLE
firewall: skip reload on DHCP lease renewal without address change

### DIFF
--- a/root/etc/hotplug.d/iface/20-firewall
+++ b/root/etc/hotplug.d/iface/20-firewall
@@ -7,7 +7,7 @@ has_zone() {
 }
 
 [ "$ACTION" = ifup -o "$ACTION" = ifupdate ] || exit 0
-[ "$ACTION" = ifupdate -a -z "$IFUPDATE_ADDRESSES" -a -z "$IFUPDATE_DATA" ] && exit 0
+[ "$ACTION" = ifupdate -a -z "$IFUPDATE_ADDRESSES" ] && exit 0
 
 /etc/init.d/firewall enabled || exit 0
 


### PR DESCRIPTION
firewall: skip reload on DHCP lease renewal without address change

Avoid unnecessary firewall reload when only DHCP lease time changes
and interface addresses remain unchanged.

Signed-off-by: Anand Kumar anandvtu16158@gmail.com