### PR TITLE
ruleset: avoid port translating local sockets

### DIFF
--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -310,6 +310,7 @@ table inet fw4 {
 {% for (let redirect in fw4.redirects("srcnat")): %}
 		{%+ include("redirect.uc", { fw4, zone: null, redirect }) %}
 {% endfor %}
+		iif 0 return
 {% for (let zone in fw4.zones()): %}
 {%  if (zone.dflags.snat): %}
 {%   for (let rule in zone.match_rules): %}

--- a/tests/01_configuration/01_ruleset
+++ b/tests/01_configuration/01_ruleset
@@ -238,6 +238,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 		oifname "pppoe-wan" jump srcnat_wan comment "!fw4: Handle wan IPv4/IPv6 srcnat traffic"
 	}
 

--- a/tests/01_configuration/02_rule_order
+++ b/tests/01_configuration/02_rule_order
@@ -183,6 +183,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/02_zones/01_policies
+++ b/tests/02_zones/01_policies
@@ -213,6 +213,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/02_zones/02_masq
+++ b/tests/02_zones/02_masq
@@ -206,6 +206,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 		oifname "zone1" jump srcnat_test1 comment "!fw4: Handle test1 IPv4/IPv6 srcnat traffic"
 		oifname "zone2" jump srcnat_test2 comment "!fw4: Handle test2 IPv4/IPv6 srcnat traffic"
 		oifname "zone3" jump srcnat_test3 comment "!fw4: Handle test3 IPv4/IPv6 srcnat traffic"

--- a/tests/02_zones/03_masq_src_dest_restrictions
+++ b/tests/02_zones/03_masq_src_dest_restrictions
@@ -206,6 +206,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 		oifname "zone1" jump srcnat_test1 comment "!fw4: Handle test1 IPv4/IPv6 srcnat traffic"
 		oifname "zone2" jump srcnat_test2 comment "!fw4: Handle test2 IPv4/IPv6 srcnat traffic"
 	}

--- a/tests/02_zones/04_masq_allow_invalid
+++ b/tests/02_zones/04_masq_allow_invalid
@@ -131,6 +131,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 		oifname "zone1" jump srcnat_test1 comment "!fw4: Handle test1 IPv4/IPv6 srcnat traffic"
 	}
 

--- a/tests/02_zones/04_wildcard_devices
+++ b/tests/02_zones/04_wildcard_devices
@@ -317,6 +317,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/02_zones/05_subnet_mask_matches
+++ b/tests/02_zones/05_subnet_mask_matches
@@ -183,6 +183,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/02_zones/06_family_selections
+++ b/tests/02_zones/06_family_selections
@@ -316,6 +316,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/02_zones/07_helpers
+++ b/tests/02_zones/07_helpers
@@ -328,6 +328,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 		oifname "zone1" jump srcnat_test1 comment "!fw4: Handle test1 IPv4/IPv6 srcnat traffic"
 		oifname "zone2" jump srcnat_test2 comment "!fw4: Handle test2 IPv4/IPv6 srcnat traffic"
 	}

--- a/tests/02_zones/08_log_limit
+++ b/tests/02_zones/08_log_limit
@@ -411,6 +411,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 		oifname "br-lan" jump srcnat_lan comment "!fw4: Handle lan IPv4/IPv6 srcnat traffic"
 		meta nfproto ipv4 oifname "pppoe-wan" jump srcnat_wan comment "!fw4: Handle wan IPv4 srcnat traffic"
 	}

--- a/tests/03_rules/01_direction
+++ b/tests/03_rules/01_direction
@@ -112,6 +112,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/03_rules/02_enabled
+++ b/tests/03_rules/02_enabled
@@ -107,6 +107,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/03_rules/03_constraints
+++ b/tests/03_rules/03_constraints
@@ -167,6 +167,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/03_rules/04_icmp
+++ b/tests/03_rules/04_icmp
@@ -119,6 +119,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/03_rules/05_mangle
+++ b/tests/03_rules/05_mangle
@@ -269,6 +269,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/03_rules/06_subnet_mask_matches
+++ b/tests/03_rules/06_subnet_mask_matches
@@ -259,6 +259,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 		oifname "pppoe-wan" jump srcnat_wan comment "!fw4: Handle wan IPv4/IPv6 srcnat traffic"
 		oifname "br-lan" jump srcnat_lan comment "!fw4: Handle lan IPv4/IPv6 srcnat traffic"
 		oifname "br-guest" jump srcnat_guest comment "!fw4: Handle guest IPv4/IPv6 srcnat traffic"

--- a/tests/03_rules/07_redirect
+++ b/tests/03_rules/07_redirect
@@ -284,6 +284,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 		oifname "pppoe-wan" jump srcnat_wan comment "!fw4: Handle wan IPv4/IPv6 srcnat traffic"
 		oifname "br-lan" jump srcnat_lan comment "!fw4: Handle lan IPv4/IPv6 srcnat traffic"
 		oifname "wwan0" jump srcnat_noaddr comment "!fw4: Handle noaddr IPv4/IPv6 srcnat traffic"

--- a/tests/03_rules/08_family_inheritance
+++ b/tests/03_rules/08_family_inheritance
@@ -269,6 +269,7 @@ table inet fw4 {
 		meta nfproto ipv4 counter masquerade comment "!fw4: NAT #3"
 		ip6 saddr fc00::/7 counter masquerade comment "!fw4: NAT #4"
 		counter masquerade comment "!fw4: NAT #6"
+		iif 0 return
 		meta nfproto ipv4 ip daddr 192.168.1.0/24 jump srcnat_ipv4only comment "!fw4: Handle ipv4only IPv4 srcnat traffic"
 	}
 

--- a/tests/03_rules/09_time
+++ b/tests/03_rules/09_time
@@ -188,6 +188,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/03_rules/10_notrack
+++ b/tests/03_rules/10_notrack
@@ -214,6 +214,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/03_rules/11_log
+++ b/tests/03_rules/11_log
@@ -177,6 +177,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 	chain dstnat_wan {

--- a/tests/03_rules/12_mark
+++ b/tests/03_rules/12_mark
@@ -135,6 +135,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/04_forwardings/01_family_selections
+++ b/tests/04_forwardings/01_family_selections
@@ -208,6 +208,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/05_ipsets/01_declaration
+++ b/tests/05_ipsets/01_declaration
@@ -125,6 +125,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/05_ipsets/02_usage
+++ b/tests/05_ipsets/02_usage
@@ -205,6 +205,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/06_includes/01_nft_includes
+++ b/tests/06_includes/01_nft_includes
@@ -218,6 +218,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/06_includes/02_firewall.user_include
+++ b/tests/06_includes/02_firewall.user_include
@@ -153,6 +153,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/06_includes/04_disabled_include
+++ b/tests/06_includes/04_disabled_include
@@ -159,6 +159,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 

--- a/tests/06_includes/05_automatic_includes
+++ b/tests/06_includes/05_automatic_includes
@@ -159,6 +159,7 @@ table inet fw4 {
 
 	chain srcnat {
 		type nat hook postrouting priority srcnat; policy accept;
+		iif 0 return
 	}
 
 


### PR DESCRIPTION
avoid allocating extra outgoing ports for local connections

Eliminate unnecesary port translation for locally originated connections
- firstly 2 ports are used for any connection, including single DNS packet
- if you run asterix or dht outgoing connections get randomized and keep ephemeral ports for long after they were relevant. i.e outgoing UDP port is unnecesarily held for 3mins, especially right after priming up dht when it pokes around the nets 1000 pipes at a time.
- once original incoming ct state expires udp based vpns get port-translated and have no chance to ever be kept alive from remote site, and eg normal site2site IKE needs to wait for timeouts to expire to get back to normal
- not a typical usage but dhcp relay with dhcp server behind NAT gets port mangled and has no chance to work
 
fixes: openwrt/openwrt#22765