### PR TITLE
ruleset: always reload entire fw4 table

### DIFF
--- a/root/sbin/fw4
+++ b/root/sbin/fw4
@@ -48,8 +48,7 @@ print() {
 stop() {
 	{
 		flock -x 1000
-
-		nft delete table inet fw4
+		nft 'destroy table inet fw4'
 		rm -f $STATE
 
 	} 1000>$LOCK
@@ -58,12 +57,7 @@ stop() {
 flush() {
 	{
 		flock -x 1000
-
-		local dummy family table
-		nft list tables | while read dummy family table; do
-			nft delete table "$family" "$table"
-		done
-
+		nft 'flush ruleset'
 		rm -f $STATE
 	} 1000>$LOCK
 }

--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -4,14 +4,8 @@
 	let defined_ipsets = fw4.ipsets();
 	let zones_with_limits = filter(fw4.zones(), z => z.log_limit);
 -%}
-
-table inet fw4
-flush table inet fw4
-{% if (fw4.check_flowtable()): %}
-delete flowtable inet fw4 ft
-{% endif %}
 {% fw4.includes('ruleset-prepend') %}
-
+destroy table inet fw4
 table inet fw4 {
 {% if (length(flowtable_devices) > 0): %}
 	#

--- a/tests/01_configuration/01_ruleset
+++ b/tests/01_configuration/01_ruleset
@@ -16,9 +16,7 @@ Testing the ruleset rendered from the default firewall configuration.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Flowtable
@@ -324,7 +322,6 @@ table inet fw4 {
 			flags offload;
 		}
 	' 2>/dev/null> timeout <null>
-[call] fs.popen cmdline </usr/sbin/nft --terse --json list flowtables inet> mode <r>
 [call] fs.readfile path </sys/class/net/br-lan/flags> limit <null>
 [call] fs.readfile path </sys/class/net/br-lan/flags> limit <null>
 -- End --

--- a/tests/01_configuration/02_rule_order
+++ b/tests/01_configuration/02_rule_order
@@ -62,9 +62,7 @@ and that rules are rendered in the order they're declared.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines
@@ -235,5 +233,4 @@ table inet fw4 {
 [call] fs.glob pattern </usr/share/nftables.d/table-post/*.nft>
 [call] fs.lsdir path </usr/share/nftables.d/chain-pre>
 [call] fs.lsdir path </usr/share/nftables.d/chain-post>
-[call] fs.popen cmdline </usr/sbin/nft --terse --json list flowtables inet> mode <r>
 -- End --

--- a/tests/02_zones/01_policies
+++ b/tests/02_zones/01_policies
@@ -61,9 +61,7 @@ Testing that zone policies are properly mapped to chains.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/02_zones/02_masq
+++ b/tests/02_zones/02_masq
@@ -65,9 +65,7 @@ Testing that zone masquerading is properly mapped to chains.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/02_zones/03_masq_src_dest_restrictions
+++ b/tests/02_zones/03_masq_src_dest_restrictions
@@ -91,9 +91,7 @@ Testing that zone masquerading restrictions source and destination restrictions 
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/02_zones/04_masq_allow_invalid
+++ b/tests/02_zones/04_masq_allow_invalid
@@ -43,9 +43,7 @@ Testing that dropping of invalid conntrack state traffic can be inhibited.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/02_zones/04_wildcard_devices
+++ b/tests/02_zones/04_wildcard_devices
@@ -82,9 +82,7 @@ Test that wildcard devices are properly handled.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/02_zones/05_subnet_mask_matches
+++ b/tests/02_zones/05_subnet_mask_matches
@@ -50,9 +50,7 @@ sets, so various permutations of rules need to be emitted.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/02_zones/06_family_selections
+++ b/tests/02_zones/06_family_selections
@@ -84,9 +84,7 @@ specified or not.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# CT helper definitions

--- a/tests/02_zones/07_helpers
+++ b/tests/02_zones/07_helpers
@@ -78,9 +78,7 @@ Testing zone helper assignments
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# CT helper definitions

--- a/tests/02_zones/08_log_limit
+++ b/tests/02_zones/08_log_limit
@@ -183,9 +183,7 @@ Test that configured zone log limits are honored in emitted log rules.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/03_rules/01_direction
+++ b/tests/03_rules/01_direction
@@ -46,9 +46,7 @@ on src and dest options.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/03_rules/02_enabled
+++ b/tests/03_rules/02_enabled
@@ -43,9 +43,7 @@ Testing that not enabled rules are ignored.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/03_rules/03_constraints
+++ b/tests/03_rules/03_constraints
@@ -79,9 +79,7 @@ Testing various option constraints.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/03_rules/04_icmp
+++ b/tests/03_rules/04_icmp
@@ -52,9 +52,7 @@ Testing handling of ICMP related options.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/03_rules/05_mangle
+++ b/tests/03_rules/05_mangle
@@ -147,9 +147,7 @@ depending on the src and dest options.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/03_rules/06_subnet_mask_matches
+++ b/tests/03_rules/06_subnet_mask_matches
@@ -99,9 +99,7 @@ permutations of rules need to be emitted.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/03_rules/07_redirect
+++ b/tests/03_rules/07_redirect
@@ -131,9 +131,7 @@ Test various address selection rules in redirect rules.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/03_rules/08_family_inheritance
+++ b/tests/03_rules/08_family_inheritance
@@ -160,9 +160,7 @@ Testing various option constraints.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Set definitions

--- a/tests/03_rules/09_time
+++ b/tests/03_rules/09_time
@@ -114,9 +114,7 @@ Ensure that time constraints are properly rendered.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/03_rules/10_notrack
+++ b/tests/03_rules/10_notrack
@@ -69,9 +69,7 @@ the src and dest options.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/03_rules/11_log
+++ b/tests/03_rules/11_log
@@ -86,9 +86,7 @@ string uses that string verbatim as log prefix.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/03_rules/12_mark
+++ b/tests/03_rules/12_mark
@@ -73,9 +73,7 @@ Testing various MARK rules.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/04_forwardings/01_family_selections
+++ b/tests/04_forwardings/01_family_selections
@@ -58,9 +58,7 @@ Test that the zone family is honoured when setting up inter-zone forwarding rule
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/05_ipsets/01_declaration
+++ b/tests/05_ipsets/01_declaration
@@ -44,9 +44,7 @@ Testing an ipset declaration.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Set definitions

--- a/tests/05_ipsets/02_usage
+++ b/tests/05_ipsets/02_usage
@@ -102,9 +102,7 @@ Linux version 5.10.113 (jow@j7) (mipsel-openwrt-linux-musl-gcc (OpenWrt GCC 11.2
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Set definitions

--- a/tests/06_includes/01_nft_includes
+++ b/tests/06_includes/01_nft_includes
@@ -124,11 +124,9 @@ Testing the correct placement of potential include positions.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
 
 include "/usr/share/nftables.d/include-ruleset-start.nft"
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/06_includes/02_firewall.user_include
+++ b/tests/06_includes/02_firewall.user_include
@@ -65,9 +65,7 @@ option to be marked compatible.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/06_includes/04_disabled_include
+++ b/tests/06_includes/04_disabled_include
@@ -71,9 +71,7 @@ Testing that include sections with `option enabled 0` are skipped.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines

--- a/tests/06_includes/05_automatic_includes
+++ b/tests/06_includes/05_automatic_includes
@@ -71,9 +71,7 @@ Testing that /usr/share/nftables.d/ includes are automatically processed.
 -- End --
 
 -- Expect stdout --
-table inet fw4
-flush table inet fw4
-
+destroy table inet fw4
 table inet fw4 {
 	#
 	# Defines


### PR DESCRIPTION
Always fully reload our table to permit future "policy drop" chains being switched on and off by an option
Obsoletes logic tracking flowtable lifecycle and avoids one nft command call somewhat backing #83

so confusing I even went upstream: https://bugzilla.netfilter.org/show_bug.cgi?id=1835