### PR TITLE
ruleset: avoid emitting default "policy accept"

### DIFF
--- a/root/etc/nftables.d/10-custom-filter-chains.nft
+++ b/root/etc/nftables.d/10-custom-filter-chains.nft
@@ -6,16 +6,16 @@
 ## default firewall input, forward and output chains.
 
 # chain user_pre_input {
-#     type filter hook input priority -1; policy accept;
+#     type filter hook input priority -1
 #     tcp dport ssh ct state new log prefix "SSH connection attempt: "
 # }
 #
 # chain user_pre_forward {
-#     type filter hook forward priority -1; policy accept;
+#     type filter hook forward priority -1
 # }
 #
 # chain user_pre_output {
-#     type filter hook output priority -1; policy accept;
+#     type filter hook output priority -1
 # }
 
 
@@ -23,17 +23,17 @@
 ## default firewall input, forward and output chains.
 
 # chain user_post_input {
-#     type filter hook input priority 1; policy accept;
+#     type filter hook input priority 1
 #     ct state new log prefix "Firewall4 accepted ingress: "
 # }
 #
 # chain user_post_forward {
-#     type filter hook forward priority 1; policy accept;
+#     type filter hook forward priority 1
 #     ct state new log prefix "Firewall4 accepted forward: "
 # }
 #
 # chain user_post_output {
-#     type filter hook output priority 1; policy accept;
+#     type filter hook output priority 1
 #     ct state new log prefix "Firewall4 accepted egress: "
 # }
 

--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -110,7 +110,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy {{ fw4.input_policy(true) }};
+		type filter hook input priority filter{% if (fw4.default_option("input")!="accept"):%}; policy drop{% endif %}
 
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
@@ -125,14 +125,14 @@ table inet fw4 {
 {% for (let zone in fw4.zones()): for (let rule in zone.match_rules): %}
 		{%+ include("zone-jump.uc", { fw4, zone, rule, direction: "input" }) %}
 {% endfor; endfor %}
-{% if (fw4.input_policy() == "reject"): %}
+{% if (fw4.default_option("input") == "reject"): %}
 		jump handle_reject
 {% endif %}
 {% fw4.includes('chain-append', 'input') %}
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy {{ fw4.forward_policy(true) }};
+		type filter hook forward priority filter{% if (fw4.default_option("forward")!="accept"):%}; policy drop{% endif %}
 
 {% if (length(flowtable_devices) > 0): %}
 		meta l4proto { tcp, udp } flow offload @ft;
@@ -146,13 +146,13 @@ table inet fw4 {
 		{%+ include("zone-jump.uc", { fw4, zone, rule, direction: "forward" }) %}
 {% endfor; endfor %}
 {% fw4.includes('chain-append', 'forward') %}
-{% if (fw4.forward_policy() == "reject"): %}
+{% if (fw4.default_option("forward") == "reject"): %}
 		jump handle_reject
 {% endif %}
 	}
 
 	chain output {
-		type filter hook output priority filter; policy {{ fw4.output_policy(true) }};
+		type filter hook output priority filter{% if (fw4.default_option("output")!="accept"):%}; policy drop{% endif %}
 
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
@@ -174,13 +174,13 @@ table inet fw4 {
 {%  endfor %}
 {% endfor %}
 {% fw4.includes('chain-append', 'output') %}
-{% if (fw4.output_policy() == "reject"): %}
+{% if (fw4.default_option("output") == "reject"): %}
 		jump handle_reject
 {% endif %}
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 {% for (let zone in fw4.zones()): %}
 {%  if (zone.dflags.helper): %}
 {%   for (let rule in zone.match_rules): %}
@@ -250,9 +250,9 @@ table inet fw4 {
 {%  endif %}
 {%  fw4.includes('chain-append', `forward_${zone.name}`) %}
 		jump {{ zone.forward }}_to_{{ zone.name }}
-{%  if (fw4.forward_policy() != "accept" && (zone.log & 1)): %}
+{%  if (fw4.default_option("forward") != "accept" && (zone.log & 1)): %}
 		{%+ if (zone.log_limit): %}limit name "{{ zone.name }}.log_limit" {%+ endif -%}
-		log prefix "{{ fw4.forward_policy() }} {{ zone.name }} forward: "
+		log prefix "{{ fw4.default_option("forward") }} {{ zone.name }} forward: "
 {%  endif %}
 	}
 
@@ -292,7 +292,7 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 {% fw4.includes('chain-prepend', 'dstnat') %}
 {% for (let zone in fw4.zones()): %}
 {%  if (zone.dflags.dnat): %}
@@ -305,7 +305,7 @@ table inet fw4 {
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 {% fw4.includes('chain-prepend', 'srcnat') %}
 {% for (let redirect in fw4.redirects("srcnat")): %}
 		{%+ include("redirect.uc", { fw4, zone: null, redirect }) %}
@@ -362,7 +362,7 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 {% for (let zone in fw4.zones()): %}
 {%  if (zone.dflags["notrack"]): %}
 {%   for (let rule in zone.match_rules): %}
@@ -378,7 +378,7 @@ table inet fw4 {
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 {% fw4.includes('chain-prepend', 'raw_output') %}
 {% for (let zone in fw4.zones()): %}
 {%  if (zone.dflags["notrack"]): %}
@@ -410,7 +410,7 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 {% fw4.includes('chain-prepend', 'mangle_prerouting') %}
 {% for (let rule in fw4.rules("mangle_prerouting")): %}
 		{%+ include("rule.uc", { fw4, zone: null, rule }) %}
@@ -419,7 +419,7 @@ table inet fw4 {
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 {% fw4.includes('chain-prepend', 'mangle_postrouting') %}
 {% for (let rule in fw4.rules("mangle_postrouting")): %}
 		{%+ include("rule.uc", { fw4, zone: null, rule }) %}
@@ -435,7 +435,7 @@ table inet fw4 {
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 {% fw4.includes('chain-prepend', 'mangle_input') %}
 {% for (let rule in fw4.rules("mangle_input")): %}
 		{%+ include("rule.uc", { fw4, zone: null, rule }) %}
@@ -444,7 +444,7 @@ table inet fw4 {
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 {% fw4.includes('chain-prepend', 'mangle_output') %}
 {% for (let rule in fw4.rules("mangle_output")): %}
 		{%+ include("rule.uc", { fw4, zone: null, rule }) %}
@@ -453,7 +453,7 @@ table inet fw4 {
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 {% fw4.includes('chain-prepend', 'mangle_forward') %}
 {% for (let rule in fw4.rules("mangle_forward")): %}
 		{%+ include("rule.uc", { fw4, zone: null, rule }) %}

--- a/root/usr/share/ucode/fw4.uc
+++ b/root/usr/share/ucode/fw4.uc
@@ -1791,19 +1791,6 @@ return {
 		return null_if_empty(filter(addrs, a => (this.is_loopback_addr(a) == invert)));
 	},
 
-
-	input_policy: function(reject_as_drop) {
-		return (!reject_as_drop || this.state.defaults.input != 'reject') ? this.state.defaults.input : 'drop';
-	},
-
-	output_policy: function(reject_as_drop) {
-		return (!reject_as_drop || this.state.defaults.output != 'reject') ? this.state.defaults.output : 'drop';
-	},
-
-	forward_policy: function(reject_as_drop) {
-		return (!reject_as_drop || this.state.defaults.forward != 'reject') ? this.state.defaults.forward : 'drop';
-	},
-
 	default_option: function(flag) {
 		return this.state.defaults[flag];
 	},

--- a/tests/01_configuration/01_ruleset
+++ b/tests/01_configuration/01_ruleset
@@ -108,8 +108,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -120,8 +119,7 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		meta l4proto { tcp, udp } flow offload @ft;
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "br-lan" jump forward_lan comment "!fw4: Handle lan IPv4/IPv6 forward traffic"
@@ -130,8 +128,7 @@ table inet fw4 {
 	}
 
 	chain output {
-		type filter hook output priority filter; policy accept;
-
+		type filter hook output priority filter
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -141,7 +138,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 		iifname "br-lan" jump helper_lan comment "!fw4: Handle lan IPv4/IPv6 helper assignment"
 	}
 
@@ -233,11 +230,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 		oifname "pppoe-wan" jump srcnat_wan comment "!fw4: Handle wan IPv4/IPv6 srcnat traffic"
 	}
 
@@ -251,11 +248,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -264,24 +261,24 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 		oifname "pppoe-wan" tcp flags syn / syn,fin,rst tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4/IPv6 egress MTU fixing"
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 		iifname "pppoe-wan" tcp flags syn / syn,fin,rst tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4/IPv6 ingress MTU fixing"
 	}
 }

--- a/tests/01_configuration/02_rule_order
+++ b/tests/01_configuration/02_rule_order
@@ -89,8 +89,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -99,16 +98,14 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "br-lan" jump forward_lan comment "!fw4: Handle lan IPv4/IPv6 forward traffic"
 		iifname "pppoe-wan" jump forward_wan comment "!fw4: Handle wan IPv4/IPv6 forward traffic"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -117,7 +114,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -178,11 +175,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -191,11 +188,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -204,23 +201,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/02_zones/01_policies
+++ b/tests/02_zones/01_policies
@@ -91,8 +91,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -102,8 +101,7 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "zone1" jump forward_test1 comment "!fw4: Handle test1 IPv4/IPv6 forward traffic"
 		iifname "zone2" jump forward_test2 comment "!fw4: Handle test2 IPv4/IPv6 forward traffic"
@@ -111,8 +109,7 @@ table inet fw4 {
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -122,7 +119,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 		iifname "zone1" jump helper_test1 comment "!fw4: Handle test1 IPv4/IPv6 helper assignment"
 		iifname "zone2" jump helper_test2 comment "!fw4: Handle test2 IPv4/IPv6 helper assignment"
 		iifname "zone3" jump helper_test3 comment "!fw4: Handle test3 IPv4/IPv6 helper assignment"
@@ -208,11 +205,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -221,11 +218,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -234,23 +231,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/02_zones/02_masq
+++ b/tests/02_zones/02_masq
@@ -95,8 +95,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -106,8 +105,7 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "zone1" jump forward_test1 comment "!fw4: Handle test1 IPv4/IPv6 forward traffic"
 		iifname "zone2" jump forward_test2 comment "!fw4: Handle test2 IPv4/IPv6 forward traffic"
@@ -115,8 +113,7 @@ table inet fw4 {
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -126,7 +123,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -201,11 +198,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 		oifname "zone1" jump srcnat_test1 comment "!fw4: Handle test1 IPv4/IPv6 srcnat traffic"
 		oifname "zone2" jump srcnat_test2 comment "!fw4: Handle test2 IPv4/IPv6 srcnat traffic"
 		oifname "zone3" jump srcnat_test3 comment "!fw4: Handle test3 IPv4/IPv6 srcnat traffic"
@@ -230,11 +227,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -243,23 +240,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/02_zones/03_masq_src_dest_restrictions
+++ b/tests/02_zones/03_masq_src_dest_restrictions
@@ -118,8 +118,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -128,16 +127,14 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "zone1" jump forward_test1 comment "!fw4: Handle test1 IPv4/IPv6 forward traffic"
 		iifname "zone2" jump forward_test2 comment "!fw4: Handle test2 IPv4/IPv6 forward traffic"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -146,7 +143,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -201,11 +198,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 		oifname "zone1" jump srcnat_test1 comment "!fw4: Handle test1 IPv4/IPv6 srcnat traffic"
 		oifname "zone2" jump srcnat_test2 comment "!fw4: Handle test2 IPv4/IPv6 srcnat traffic"
 	}
@@ -224,11 +221,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -237,23 +234,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/02_zones/04_masq_allow_invalid
+++ b/tests/02_zones/04_masq_allow_invalid
@@ -67,8 +67,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -76,15 +75,13 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "zone1" jump forward_test1 comment "!fw4: Handle test1 IPv4/IPv6 forward traffic"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -92,7 +89,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -126,11 +123,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 		oifname "zone1" jump srcnat_test1 comment "!fw4: Handle test1 IPv4/IPv6 srcnat traffic"
 	}
 
@@ -144,11 +141,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -157,23 +154,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/02_zones/04_wildcard_devices
+++ b/tests/02_zones/04_wildcard_devices
@@ -118,8 +118,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -135,8 +134,7 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		jump forward_test1 comment "!fw4: Handle test1 IPv4/IPv6 forward traffic"
 		iifname "/never/" jump forward_test2 comment "!fw4: Handle test2 IPv4/IPv6 forward traffic"
@@ -150,8 +148,7 @@ table inet fw4 {
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -167,7 +164,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 		iifname "/never/" jump helper_test2 comment "!fw4: Handle test2 IPv4/IPv6 helper assignment"
 		iifname "test*" jump helper_test3 comment "!fw4: Handle test3 IPv4/IPv6 helper assignment"
 		iifname "foo*" jump helper_test4 comment "!fw4: Handle test4 IPv4/IPv6 helper assignment"
@@ -312,11 +309,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -325,11 +322,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -338,23 +335,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/02_zones/05_subnet_mask_matches
+++ b/tests/02_zones/05_subnet_mask_matches
@@ -77,8 +77,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -89,8 +88,7 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		meta nfproto ipv6 ip6 saddr & ::ffff == ::1 ip6 saddr & ::ffff != ::2 jump forward_test1 comment "!fw4: Handle test1 IPv6 forward traffic"
 		meta nfproto ipv6 ip6 saddr != { ::7, ::8 } ip6 saddr & ::ffff == ::1 ip6 saddr & ::ffff != ::5 ip6 saddr & ::ffff != ::6 jump forward_test2 comment "!fw4: Handle test2 IPv6 forward traffic"
@@ -99,8 +97,7 @@ table inet fw4 {
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -111,7 +108,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 		meta nfproto ipv6 ip6 saddr != { ::7, ::8 } ip6 saddr & ::ffff == ::1 ip6 saddr & ::ffff != ::5 ip6 saddr & ::ffff != ::6 jump helper_test2 comment "!fw4: Handle test2 IPv6 helper assignment"
 		meta nfproto ipv6 ip6 saddr != { ::7, ::8 } ip6 saddr & ::ffff == ::2 ip6 saddr & ::ffff != ::5 ip6 saddr & ::ffff != ::6 jump helper_test2 comment "!fw4: Handle test2 IPv6 helper assignment"
 		meta nfproto ipv6 ip6 saddr { ::3, ::4 } ip6 saddr != { ::7, ::8 } ip6 saddr & ::ffff != ::5 ip6 saddr & ::ffff != ::6 jump helper_test2 comment "!fw4: Handle test2 IPv6 helper assignment"
@@ -178,11 +175,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -191,11 +188,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -204,23 +201,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/02_zones/06_family_selections
+++ b/tests/02_zones/06_family_selections
@@ -132,8 +132,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -146,8 +145,7 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		meta nfproto ipv4 ip saddr 10.0.0.0/8 jump forward_test1 comment "!fw4: Handle test1 IPv4 forward traffic"
 		meta nfproto ipv6 ip6 saddr 2001:db8:1234::/64 jump forward_test2 comment "!fw4: Handle test2 IPv6 forward traffic"
@@ -158,8 +156,7 @@ table inet fw4 {
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -172,7 +169,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 		iifname "br-lan" jump helper_test6 comment "!fw4: Handle test6 IPv4/IPv6 helper assignment"
 	}
 
@@ -311,11 +308,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -324,11 +321,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -337,23 +334,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/02_zones/07_helpers
+++ b/tests/02_zones/07_helpers
@@ -164,8 +164,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -176,8 +175,7 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "zone1" jump forward_test1 comment "!fw4: Handle test1 IPv4/IPv6 forward traffic"
 		iifname "zone2" jump forward_test2 comment "!fw4: Handle test2 IPv4/IPv6 forward traffic"
@@ -186,8 +184,7 @@ table inet fw4 {
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -198,7 +195,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 		iifname "zone1" jump helper_test1 comment "!fw4: Handle test1 IPv4/IPv6 helper assignment"
 		iifname "zone2" jump helper_test2 comment "!fw4: Handle test2 IPv4/IPv6 helper assignment"
 		iifname "zone3" jump helper_test3 comment "!fw4: Handle test3 IPv4/IPv6 helper assignment"
@@ -323,11 +320,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 		oifname "zone1" jump srcnat_test1 comment "!fw4: Handle test1 IPv4/IPv6 srcnat traffic"
 		oifname "zone2" jump srcnat_test2 comment "!fw4: Handle test2 IPv4/IPv6 srcnat traffic"
 	}
@@ -346,11 +343,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -359,23 +356,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/02_zones/08_log_limit
+++ b/tests/02_zones/08_log_limit
@@ -236,8 +236,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -252,8 +251,7 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		tcp dport 1005 limit name "lan.log_limit" log prefix "@rule[4]: "
 		tcp dport 1005 counter comment "!fw4: @rule[4]"
@@ -265,8 +263,7 @@ table inet fw4 {
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -277,7 +274,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -404,13 +401,13 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 		iifname "br-lan" jump dstnat_lan comment "!fw4: Handle lan IPv4/IPv6 dstnat traffic"
 		meta nfproto ipv4 iifname "pppoe-wan" jump dstnat_wan comment "!fw4: Handle wan IPv4 dstnat traffic"
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 		oifname "br-lan" jump srcnat_lan comment "!fw4: Handle lan IPv4/IPv6 srcnat traffic"
 		meta nfproto ipv4 oifname "pppoe-wan" jump srcnat_wan comment "!fw4: Handle wan IPv4 srcnat traffic"
 	}
@@ -442,11 +439,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -455,23 +452,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/03_rules/01_direction
+++ b/tests/03_rules/01_direction
@@ -67,8 +67,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -76,15 +75,13 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		counter comment "!fw4: @rule[3]"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -93,7 +90,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -107,11 +104,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -120,11 +117,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -133,23 +130,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/03_rules/02_enabled
+++ b/tests/03_rules/02_enabled
@@ -64,22 +64,19 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -88,7 +85,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -102,11 +99,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -115,11 +112,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -128,23 +125,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/03_rules/03_constraints
+++ b/tests/03_rules/03_constraints
@@ -103,22 +103,19 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -127,7 +124,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -162,11 +159,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -175,11 +172,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -188,23 +185,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/03_rules/04_icmp
+++ b/tests/03_rules/04_icmp
@@ -73,22 +73,19 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -100,7 +97,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -114,11 +111,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -127,11 +124,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -140,23 +137,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/03_rules/05_mangle
+++ b/tests/03_rules/05_mangle
@@ -174,8 +174,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -184,16 +183,14 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname { "eth0", "eth1" } jump forward_lan comment "!fw4: Handle lan IPv4/IPv6 forward traffic"
 		iifname { "eth2", "eth3" } jump forward_wan comment "!fw4: Handle wan IPv4/IPv6 forward traffic"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -202,7 +199,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 		iifname { "eth0", "eth1" } jump helper_lan comment "!fw4: Handle lan IPv4/IPv6 helper assignment"
 		iifname { "eth2", "eth3" } jump helper_wan comment "!fw4: Handle wan IPv4/IPv6 helper assignment"
 	}
@@ -264,11 +261,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -277,11 +274,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -290,7 +287,7 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 		meta nfproto ipv4 meta l4proto tcp iifname { "eth0", "eth1" } counter ip dscp set 0x1 comment "!fw4: Mangle rule #4"
 		meta nfproto ipv6 meta l4proto tcp iifname { "eth0", "eth1" } counter ip6 dscp set 0x1 comment "!fw4: Mangle rule #4"
 		meta nfproto ipv4 meta l4proto udp iifname { "eth0", "eth1" } counter ip dscp set 0x1 comment "!fw4: Mangle rule #4"
@@ -298,7 +295,7 @@ table inet fw4 {
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 		meta nfproto ipv4 meta l4proto tcp oifname { "eth2", "eth3" } counter ip dscp set 0x1 comment "!fw4: Mangle rule #3"
 		meta nfproto ipv6 meta l4proto tcp oifname { "eth2", "eth3" } counter ip6 dscp set 0x1 comment "!fw4: Mangle rule #3"
 		meta nfproto ipv4 meta l4proto udp oifname { "eth2", "eth3" } counter ip dscp set 0x1 comment "!fw4: Mangle rule #3"
@@ -318,7 +315,7 @@ table inet fw4 {
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 		meta nfproto ipv4 meta l4proto tcp iifname { "eth0", "eth1" } counter ip dscp set 0x1 comment "!fw4: Mangle rule #5"
 		meta nfproto ipv6 meta l4proto tcp iifname { "eth0", "eth1" } counter ip6 dscp set 0x1 comment "!fw4: Mangle rule #5"
 		meta nfproto ipv4 meta l4proto udp iifname { "eth0", "eth1" } counter ip dscp set 0x1 comment "!fw4: Mangle rule #5"
@@ -330,7 +327,7 @@ table inet fw4 {
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 		meta nfproto ipv4 meta l4proto tcp counter ip dscp set 0x1 comment "!fw4: Mangle rule #7"
 		meta nfproto ipv6 meta l4proto tcp counter ip6 dscp set 0x1 comment "!fw4: Mangle rule #7"
 		meta nfproto ipv4 meta l4proto udp counter ip dscp set 0x1 comment "!fw4: Mangle rule #7"
@@ -346,7 +343,7 @@ table inet fw4 {
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 		meta nfproto ipv4 meta l4proto tcp counter ip dscp set 0x1 comment "!fw4: Mangle rule #1"
 		meta nfproto ipv6 meta l4proto tcp counter ip6 dscp set 0x1 comment "!fw4: Mangle rule #1"
 		meta nfproto ipv4 meta l4proto udp counter ip dscp set 0x1 comment "!fw4: Mangle rule #1"

--- a/tests/03_rules/06_subnet_mask_matches
+++ b/tests/03_rules/06_subnet_mask_matches
@@ -129,8 +129,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -140,8 +139,7 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "pppoe-wan" jump forward_wan comment "!fw4: Handle wan IPv4/IPv6 forward traffic"
 		iifname "br-lan" jump forward_lan comment "!fw4: Handle lan IPv4/IPv6 forward traffic"
@@ -149,8 +147,7 @@ table inet fw4 {
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -171,7 +168,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -251,14 +248,14 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 		iifname "pppoe-wan" jump dstnat_wan comment "!fw4: Handle wan IPv4/IPv6 dstnat traffic"
 		iifname "br-lan" jump dstnat_lan comment "!fw4: Handle lan IPv4/IPv6 dstnat traffic"
 		iifname "br-guest" jump dstnat_guest comment "!fw4: Handle guest IPv4/IPv6 dstnat traffic"
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 		oifname "pppoe-wan" jump srcnat_wan comment "!fw4: Handle wan IPv4/IPv6 srcnat traffic"
 		oifname "br-lan" jump srcnat_lan comment "!fw4: Handle lan IPv4/IPv6 srcnat traffic"
 		oifname "br-guest" jump srcnat_guest comment "!fw4: Handle guest IPv4/IPv6 srcnat traffic"
@@ -294,11 +291,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -307,23 +304,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/03_rules/07_redirect
+++ b/tests/03_rules/07_redirect
@@ -161,8 +161,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -172,8 +171,7 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "pppoe-wan" jump forward_wan comment "!fw4: Handle wan IPv4/IPv6 forward traffic"
 		iifname "br-lan" jump forward_lan comment "!fw4: Handle lan IPv4/IPv6 forward traffic"
@@ -181,8 +179,7 @@ table inet fw4 {
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -192,7 +189,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -276,14 +273,14 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 		iifname "pppoe-wan" jump dstnat_wan comment "!fw4: Handle wan IPv4/IPv6 dstnat traffic"
 		iifname "br-lan" jump dstnat_lan comment "!fw4: Handle lan IPv4/IPv6 dstnat traffic"
 		iifname "wwan0" jump dstnat_noaddr comment "!fw4: Handle noaddr IPv4/IPv6 dstnat traffic"
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 		oifname "pppoe-wan" jump srcnat_wan comment "!fw4: Handle wan IPv4/IPv6 srcnat traffic"
 		oifname "br-lan" jump srcnat_lan comment "!fw4: Handle lan IPv4/IPv6 srcnat traffic"
 		oifname "wwan0" jump srcnat_noaddr comment "!fw4: Handle noaddr IPv4/IPv6 srcnat traffic"
@@ -331,11 +328,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -344,23 +341,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/03_rules/08_family_inheritance
+++ b/tests/03_rules/08_family_inheritance
@@ -198,8 +198,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -207,15 +206,13 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		meta nfproto ipv4 ip saddr 192.168.1.0/24 jump forward_ipv4only comment "!fw4: Handle ipv4only IPv4 forward traffic"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -223,7 +220,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -260,12 +257,12 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 		meta nfproto ipv4 ip saddr 192.168.1.0/24 jump dstnat_ipv4only comment "!fw4: Handle ipv4only IPv4 dstnat traffic"
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 		meta nfproto ipv4 counter masquerade comment "!fw4: NAT #3"
 		ip6 saddr fc00::/7 counter masquerade comment "!fw4: NAT #4"
 		counter masquerade comment "!fw4: NAT #6"
@@ -285,11 +282,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -298,23 +295,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/03_rules/09_time
+++ b/tests/03_rules/09_time
@@ -135,22 +135,19 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -169,7 +166,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -183,11 +180,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -196,11 +193,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -209,23 +206,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/03_rules/10_notrack
+++ b/tests/03_rules/10_notrack
@@ -99,8 +99,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -111,8 +110,7 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "eth0" jump forward_zone1 comment "!fw4: Handle zone1 IPv4/IPv6 forward traffic"
 		iifname "lo" jump forward_zone2 comment "!fw4: Handle zone2 IPv4/IPv6 forward traffic"
@@ -121,8 +119,7 @@ table inet fw4 {
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -133,7 +130,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -209,11 +206,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -222,12 +219,12 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 		iifname "eth0" jump notrack_zone1 comment "!fw4: Handle zone1 IPv4/IPv6 notrack traffic"
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 		iifname "lo" jump notrack_zone2 comment "!fw4: Handle zone2 IPv4/IPv6 notrack traffic"
 		meta nfproto ipv4 ip saddr 127.0.0.0/8 jump notrack_zone3 comment "!fw4: Handle zone3 IPv4 notrack traffic"
 		meta nfproto ipv6 ip6 saddr ::1 jump notrack_zone3 comment "!fw4: Handle zone3 IPv6 notrack traffic"
@@ -254,23 +251,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/03_rules/11_log
+++ b/tests/03_rules/11_log
@@ -110,22 +110,19 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -135,7 +132,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -172,11 +169,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 	chain dstnat_wan {
@@ -197,11 +194,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -210,23 +207,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/03_rules/12_mark
+++ b/tests/03_rules/12_mark
@@ -94,29 +94,26 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -130,11 +127,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -143,11 +140,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -156,15 +153,15 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 		counter meta mark set 0xaa comment "!fw4: Mark rule #1"
 		counter meta mark set mark and 0xffff0054 xor 0xab comment "!fw4: Mark rule #2"
 		counter meta mark set 0xac comment "!fw4: Mark rule #3"
@@ -174,11 +171,11 @@ table inet fw4 {
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/04_forwardings/01_family_selections
+++ b/tests/04_forwardings/01_family_selections
@@ -88,8 +88,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -99,8 +98,7 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "eth0" jump forward_wanA comment "!fw4: Handle wanA IPv4/IPv6 forward traffic"
 		iifname "eth1" jump forward_wanB comment "!fw4: Handle wanB IPv4/IPv6 forward traffic"
@@ -108,8 +106,7 @@ table inet fw4 {
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -119,7 +116,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -203,11 +200,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -216,11 +213,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -229,23 +226,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/05_ipsets/01_declaration
+++ b/tests/05_ipsets/01_declaration
@@ -84,29 +84,26 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -120,11 +117,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -133,11 +130,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -146,23 +143,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/05_ipsets/02_usage
+++ b/tests/05_ipsets/02_usage
@@ -158,16 +158,14 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		meta nfproto ipv4 meta l4proto tcp ip saddr . tcp dport @test-set-1 counter comment "!fw4: Rule using test set #1"
 		meta nfproto ipv4 meta l4proto tcp ip saddr . tcp sport @test-set-2 counter comment "!fw4: Rule using test set #2, match direction should default to 'source'"
@@ -178,15 +176,14 @@ table inet fw4 {
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -200,11 +197,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -213,11 +210,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -226,23 +223,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/06_includes/01_nft_includes
+++ b/tests/06_includes/01_nft_includes
@@ -152,8 +152,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -161,8 +160,7 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		include "/usr/share/nftables.d/include-chain-start-forward.nft"
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "eth0" jump forward_test comment "!fw4: Handle test IPv4/IPv6 forward traffic"
@@ -170,8 +168,7 @@ table inet fw4 {
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -179,7 +176,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -213,11 +210,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -226,11 +223,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -239,23 +236,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 
 	include "/usr/share/nftables.d/include-table-end-1.nft"

--- a/tests/06_includes/02_firewall.user_include
+++ b/tests/06_includes/02_firewall.user_include
@@ -89,8 +89,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -98,15 +97,13 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "eth0" jump forward_test comment "!fw4: Handle test IPv4/IPv6 forward traffic"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -114,7 +111,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -148,11 +145,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -161,11 +158,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -174,23 +171,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 }
 -- End --

--- a/tests/06_includes/04_disabled_include
+++ b/tests/06_includes/04_disabled_include
@@ -95,8 +95,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -104,15 +103,13 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "eth0" jump forward_test comment "!fw4: Handle test IPv4/IPv6 forward traffic"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -120,7 +117,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -154,11 +151,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -167,11 +164,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -180,23 +177,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 
 	include "/etc/testinclude1.nft"

--- a/tests/06_includes/05_automatic_includes
+++ b/tests/06_includes/05_automatic_includes
@@ -95,8 +95,7 @@ table inet fw4 {
 	#
 
 	chain input {
-		type filter hook input priority filter; policy drop;
-
+		type filter hook input priority filter; policy drop
 		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle inbound flows"
@@ -104,15 +103,13 @@ table inet fw4 {
 	}
 
 	chain forward {
-		type filter hook forward priority filter; policy drop;
-
+		type filter hook forward priority filter; policy drop
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle forwarded flows"
 		iifname "eth0" jump forward_test comment "!fw4: Handle test IPv4/IPv6 forward traffic"
 	}
 
 	chain output {
-		type filter hook output priority filter; policy drop;
-
+		type filter hook output priority filter; policy drop
 		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 
 		ct state vmap { established : accept, related : accept } comment "!fw4: Handle outbound flows"
@@ -120,7 +117,7 @@ table inet fw4 {
 	}
 
 	chain prerouting {
-		type filter hook prerouting priority filter; policy accept;
+		type filter hook prerouting priority filter
 	}
 
 	chain handle_reject {
@@ -154,11 +151,11 @@ table inet fw4 {
 	#
 
 	chain dstnat {
-		type nat hook prerouting priority dstnat; policy accept;
+		type nat hook prerouting priority dstnat
 	}
 
 	chain srcnat {
-		type nat hook postrouting priority srcnat; policy accept;
+		type nat hook postrouting priority srcnat
 	}
 
 
@@ -167,11 +164,11 @@ table inet fw4 {
 	#
 
 	chain raw_prerouting {
-		type filter hook prerouting priority raw; policy accept;
+		type filter hook prerouting priority raw
 	}
 
 	chain raw_output {
-		type filter hook output priority raw; policy accept;
+		type filter hook output priority raw
 	}
 
 
@@ -180,23 +177,23 @@ table inet fw4 {
 	#
 
 	chain mangle_prerouting {
-		type filter hook prerouting priority mangle; policy accept;
+		type filter hook prerouting priority mangle
 	}
 
 	chain mangle_postrouting {
-		type filter hook postrouting priority mangle; policy accept;
+		type filter hook postrouting priority mangle
 	}
 
 	chain mangle_input {
-		type filter hook input priority mangle; policy accept;
+		type filter hook input priority mangle
 	}
 
 	chain mangle_output {
-		type route hook output priority mangle; policy accept;
+		type route hook output priority mangle
 	}
 
 	chain mangle_forward {
-		type filter hook forward priority mangle; policy accept;
+		type filter hook forward priority mangle
 	}
 
 	include "/etc/testinclude1.nft"


### PR DESCRIPTION
- Do not emit default ";policy accept;" flag since it is the default
- Inline 3 nearly identical "default policy" indirections replacing with checking parameters they abstracted
- no change in resulting in-kernel ruleset
- test 01/01 already covers all altered code paths