### PR TITLE
ruleset: make more robust against package mistakes

### DIFF
--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -78,8 +78,8 @@ table inet fw4 {
 	#
 
 {% for (let zone in fw4.zones()): %}
-	define {{ replace(zone.name, /^[0-9]/, '_$&') }}_devices = {{ fw4.set(zone.match_devices, true) }}
-	define {{ replace(zone.name, /^[0-9]/, '_$&') }}_subnets = {{ fw4.set(zone.match_subnets, true) }}
+	redefine {{ replace(zone.name, /^[0-9]/, '_$&') }}_devices = {{ fw4.set(zone.match_devices, true) }}
+	redefine {{ replace(zone.name, /^[0-9]/, '_$&') }}_subnets = {{ fw4.set(zone.match_subnets, true) }}
 
 {% endfor %}
 

--- a/tests/01_configuration/01_ruleset
+++ b/tests/01_configuration/01_ruleset
@@ -89,11 +89,11 @@ table inet fw4 {
 	# Defines
 	#
 
-	define lan_devices = { "br-lan" }
-	define lan_subnets = { 10.0.0.0/24, 192.168.26.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
+	redefine lan_devices = { "br-lan" }
+	redefine lan_subnets = { 10.0.0.0/24, 192.168.26.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
 
-	define wan_devices = { "pppoe-wan" }
-	define wan_subnets = { 10.11.12.0/24, 2001:db8:54:321::/64 }
+	redefine wan_devices = { "pppoe-wan" }
+	redefine wan_subnets = { 10.11.12.0/24, 2001:db8:54:321::/64 }
 
 
 	#

--- a/tests/01_configuration/02_rule_order
+++ b/tests/01_configuration/02_rule_order
@@ -70,11 +70,11 @@ table inet fw4 {
 	# Defines
 	#
 
-	define lan_devices = { "br-lan" }
-	define lan_subnets = { 10.0.0.0/24, 192.168.26.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
+	redefine lan_devices = { "br-lan" }
+	redefine lan_subnets = { 10.0.0.0/24, 192.168.26.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
 
-	define wan_devices = { "pppoe-wan" }
-	define wan_subnets = { 10.11.12.0/24 }
+	redefine wan_devices = { "pppoe-wan" }
+	redefine wan_subnets = { 10.11.12.0/24 }
 
 
 	#

--- a/tests/02_zones/01_policies
+++ b/tests/02_zones/01_policies
@@ -69,14 +69,14 @@ table inet fw4 {
 	# Defines
 	#
 
-	define test1_devices = { "zone1" }
-	define test1_subnets = {  }
+	redefine test1_devices = { "zone1" }
+	redefine test1_subnets = {  }
 
-	define test2_devices = { "zone2" }
-	define test2_subnets = {  }
+	redefine test2_devices = { "zone2" }
+	redefine test2_subnets = {  }
 
-	define test3_devices = { "zone3" }
-	define test3_subnets = {  }
+	redefine test3_devices = { "zone3" }
+	redefine test3_subnets = {  }
 
 
 	#

--- a/tests/02_zones/02_masq
+++ b/tests/02_zones/02_masq
@@ -73,14 +73,14 @@ table inet fw4 {
 	# Defines
 	#
 
-	define test1_devices = { "zone1" }
-	define test1_subnets = {  }
+	redefine test1_devices = { "zone1" }
+	redefine test1_subnets = {  }
 
-	define test2_devices = { "zone2" }
-	define test2_subnets = {  }
+	redefine test2_devices = { "zone2" }
+	redefine test2_subnets = {  }
 
-	define test3_devices = { "zone3" }
-	define test3_subnets = {  }
+	redefine test3_devices = { "zone3" }
+	redefine test3_subnets = {  }
 
 
 	#

--- a/tests/02_zones/03_masq_src_dest_restrictions
+++ b/tests/02_zones/03_masq_src_dest_restrictions
@@ -99,11 +99,11 @@ table inet fw4 {
 	# Defines
 	#
 
-	define test1_devices = { "zone1" }
-	define test1_subnets = {  }
+	redefine test1_devices = { "zone1" }
+	redefine test1_subnets = {  }
 
-	define test2_devices = { "zone2" }
-	define test2_subnets = {  }
+	redefine test2_devices = { "zone2" }
+	redefine test2_subnets = {  }
 
 
 	#

--- a/tests/02_zones/04_masq_allow_invalid
+++ b/tests/02_zones/04_masq_allow_invalid
@@ -51,8 +51,8 @@ table inet fw4 {
 	# Defines
 	#
 
-	define test1_devices = { "zone1" }
-	define test1_subnets = {  }
+	redefine test1_devices = { "zone1" }
+	redefine test1_subnets = {  }
 
 
 	#

--- a/tests/02_zones/04_wildcard_devices
+++ b/tests/02_zones/04_wildcard_devices
@@ -90,20 +90,20 @@ table inet fw4 {
 	# Defines
 	#
 
-	define test1_devices = { "+" }
-	define test1_subnets = {  }
+	redefine test1_devices = { "+" }
+	redefine test1_subnets = {  }
 
-	define test2_devices = { "/never/" }
-	define test2_subnets = {  }
+	redefine test2_devices = { "/never/" }
+	redefine test2_subnets = {  }
 
-	define test3_devices = { "test*" }
-	define test3_subnets = {  }
+	redefine test3_devices = { "test*" }
+	redefine test3_subnets = {  }
 
-	define test4_devices = { "foo*", "bar*", "test1", "test2" }
-	define test4_subnets = {  }
+	redefine test4_devices = { "foo*", "bar*", "test1", "test2" }
+	redefine test4_subnets = {  }
 
-	define test5_devices = { "foo*", "bar*", "test1", "test2" }
-	define test5_subnets = {  }
+	redefine test5_devices = { "foo*", "bar*", "test1", "test2" }
+	redefine test5_subnets = {  }
 
 
 	#

--- a/tests/02_zones/05_subnet_mask_matches
+++ b/tests/02_zones/05_subnet_mask_matches
@@ -58,11 +58,11 @@ table inet fw4 {
 	# Defines
 	#
 
-	define test1_devices = {  }
-	define test1_subnets = {  }
+	redefine test1_devices = {  }
+	redefine test1_subnets = {  }
 
-	define test2_devices = {  }
-	define test2_subnets = { ::3, ::4 }
+	redefine test2_devices = {  }
+	redefine test2_subnets = { ::3, ::4 }
 
 
 	#

--- a/tests/02_zones/06_family_selections
+++ b/tests/02_zones/06_family_selections
@@ -101,23 +101,23 @@ table inet fw4 {
 	# Defines
 	#
 
-	define test1_devices = {  }
-	define test1_subnets = { 10.0.0.0/8 }
+	redefine test1_devices = {  }
+	redefine test1_subnets = { 10.0.0.0/8 }
 
-	define test2_devices = {  }
-	define test2_subnets = { 2001:db8:1234::/64 }
+	redefine test2_devices = {  }
+	redefine test2_subnets = { 2001:db8:1234::/64 }
 
-	define test3_devices = {  }
-	define test3_subnets = { 2001:db8:1234::/64 }
+	redefine test3_devices = {  }
+	redefine test3_subnets = { 2001:db8:1234::/64 }
 
-	define test4_devices = {  }
-	define test4_subnets = { 2001:db8:1234::/64 }
+	redefine test4_devices = {  }
+	redefine test4_subnets = { 2001:db8:1234::/64 }
 
-	define test5_devices = { "eth0" }
-	define test5_subnets = {  }
+	redefine test5_devices = { "eth0" }
+	redefine test5_subnets = {  }
 
-	define test6_devices = { "br-lan" }
-	define test6_subnets = {  }
+	redefine test6_devices = { "br-lan" }
+	redefine test6_subnets = {  }
 
 
 	#

--- a/tests/02_zones/07_helpers
+++ b/tests/02_zones/07_helpers
@@ -139,17 +139,17 @@ table inet fw4 {
 	# Defines
 	#
 
-	define test1_devices = { "zone1" }
-	define test1_subnets = {  }
+	redefine test1_devices = { "zone1" }
+	redefine test1_subnets = {  }
 
-	define test2_devices = { "zone2" }
-	define test2_subnets = {  }
+	redefine test2_devices = { "zone2" }
+	redefine test2_subnets = {  }
 
-	define test3_devices = { "zone3" }
-	define test3_subnets = {  }
+	redefine test3_devices = { "zone3" }
+	redefine test3_subnets = {  }
 
-	define test4_devices = { "zone4" }
-	define test4_subnets = {  }
+	redefine test4_devices = { "zone4" }
+	redefine test4_subnets = {  }
 
 
 	#

--- a/tests/02_zones/08_log_limit
+++ b/tests/02_zones/08_log_limit
@@ -191,17 +191,17 @@ table inet fw4 {
 	# Defines
 	#
 
-	define lan_devices = { "br-lan" }
-	define lan_subnets = { 10.0.0.0/24, 192.168.26.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
+	redefine lan_devices = { "br-lan" }
+	redefine lan_subnets = { 10.0.0.0/24, 192.168.26.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
 
-	define wan_devices = { "pppoe-wan" }
-	define wan_subnets = { 10.11.12.0/24 }
+	redefine wan_devices = { "pppoe-wan" }
+	redefine wan_subnets = { 10.11.12.0/24 }
 
-	define guest_devices = { "br-guest" }
-	define guest_subnets = { 10.1.0.0/24, 192.168.27.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
+	redefine guest_devices = { "br-guest" }
+	redefine guest_subnets = { 10.1.0.0/24, 192.168.27.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
 
-	define wan6_devices = { "pppoe-wan" }
-	define wan6_subnets = { 2001:db8:54:321::/64 }
+	redefine wan6_devices = { "pppoe-wan" }
+	redefine wan6_subnets = { 2001:db8:54:321::/64 }
 
 
 	#

--- a/tests/03_rules/03_constraints
+++ b/tests/03_rules/03_constraints
@@ -87,8 +87,8 @@ table inet fw4 {
 	# Defines
 	#
 
-	define lan_devices = {  }
-	define lan_subnets = {  }
+	redefine lan_devices = {  }
+	redefine lan_subnets = {  }
 
 
 	#

--- a/tests/03_rules/05_mangle
+++ b/tests/03_rules/05_mangle
@@ -155,11 +155,11 @@ table inet fw4 {
 	# Defines
 	#
 
-	define lan_devices = { "eth0", "eth1" }
-	define lan_subnets = {  }
+	redefine lan_devices = { "eth0", "eth1" }
+	redefine lan_subnets = {  }
 
-	define wan_devices = { "eth2", "eth3" }
-	define wan_subnets = {  }
+	redefine wan_devices = { "eth2", "eth3" }
+	redefine wan_subnets = {  }
 
 
 	#

--- a/tests/03_rules/06_subnet_mask_matches
+++ b/tests/03_rules/06_subnet_mask_matches
@@ -107,14 +107,14 @@ table inet fw4 {
 	# Defines
 	#
 
-	define wan_devices = { "pppoe-wan" }
-	define wan_subnets = { 2001:db8:54:321::/64 }
+	redefine wan_devices = { "pppoe-wan" }
+	redefine wan_subnets = { 2001:db8:54:321::/64 }
 
-	define lan_devices = { "br-lan" }
-	define lan_subnets = { 10.0.0.0/24, 192.168.26.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
+	redefine lan_devices = { "br-lan" }
+	redefine lan_subnets = { 10.0.0.0/24, 192.168.26.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
 
-	define guest_devices = { "br-guest" }
-	define guest_subnets = { 10.1.0.0/24, 192.168.27.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
+	redefine guest_devices = { "br-guest" }
+	redefine guest_subnets = { 10.1.0.0/24, 192.168.27.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
 
 
 	#

--- a/tests/03_rules/07_redirect
+++ b/tests/03_rules/07_redirect
@@ -139,14 +139,14 @@ table inet fw4 {
 	# Defines
 	#
 
-	define wan_devices = { "pppoe-wan" }
-	define wan_subnets = { 10.11.12.0/24, 2001:db8:54:321::/64 }
+	redefine wan_devices = { "pppoe-wan" }
+	redefine wan_subnets = { 10.11.12.0/24, 2001:db8:54:321::/64 }
 
-	define lan_devices = { "br-lan" }
-	define lan_subnets = { 10.0.0.0/24, 192.168.26.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
+	redefine lan_devices = { "br-lan" }
+	redefine lan_subnets = { 10.0.0.0/24, 192.168.26.0/24, 2001:db8:1000::/60, fd63:e2f:f706::/60 }
 
-	define noaddr_devices = { "wwan0" }
-	define noaddr_subnets = {  }
+	redefine noaddr_devices = { "wwan0" }
+	redefine noaddr_subnets = {  }
 
 
 	#

--- a/tests/03_rules/08_family_inheritance
+++ b/tests/03_rules/08_family_inheritance
@@ -182,8 +182,8 @@ table inet fw4 {
 	# Defines
 	#
 
-	define ipv4only_devices = {  }
-	define ipv4only_subnets = { 192.168.1.0/24 }
+	redefine ipv4only_devices = {  }
+	redefine ipv4only_subnets = { 192.168.1.0/24 }
 
 
 	#

--- a/tests/03_rules/10_notrack
+++ b/tests/03_rules/10_notrack
@@ -77,14 +77,14 @@ table inet fw4 {
 	# Defines
 	#
 
-	define zone1_devices = { "eth0" }
-	define zone1_subnets = {  }
+	redefine zone1_devices = { "eth0" }
+	redefine zone1_subnets = {  }
 
-	define zone2_devices = { "lo" }
-	define zone2_subnets = {  }
+	redefine zone2_devices = { "lo" }
+	redefine zone2_subnets = {  }
 
-	define zone3_devices = {  }
-	define zone3_subnets = { 127.0.0.0/8, ::1 }
+	redefine zone3_devices = {  }
+	redefine zone3_subnets = { 127.0.0.0/8, ::1 }
 
 
 	#

--- a/tests/03_rules/11_log
+++ b/tests/03_rules/11_log
@@ -94,8 +94,8 @@ table inet fw4 {
 	# Defines
 	#
 
-	define wan_devices = {  }
-	define wan_subnets = {  }
+	redefine wan_devices = {  }
+	redefine wan_subnets = {  }
 
 
 	#

--- a/tests/04_forwardings/01_family_selections
+++ b/tests/04_forwardings/01_family_selections
@@ -66,14 +66,14 @@ table inet fw4 {
 	# Defines
 	#
 
-	define wanA_devices = { "eth0" }
-	define wanA_subnets = {  }
+	redefine wanA_devices = { "eth0" }
+	redefine wanA_subnets = {  }
 
-	define wanB_devices = { "eth1" }
-	define wanB_subnets = {  }
+	redefine wanB_devices = { "eth1" }
+	redefine wanB_subnets = {  }
 
-	define lan_devices = { "eth2" }
-	define lan_subnets = {  }
+	redefine lan_devices = { "eth2" }
+	redefine lan_subnets = {  }
 
 
 	#

--- a/tests/06_includes/01_nft_includes
+++ b/tests/06_includes/01_nft_includes
@@ -134,8 +134,8 @@ table inet fw4 {
 	# Defines
 	#
 
-	define test_devices = { "eth0" }
-	define test_subnets = {  }
+	redefine test_devices = { "eth0" }
+	redefine test_subnets = {  }
 
 
 	#

--- a/tests/06_includes/02_firewall.user_include
+++ b/tests/06_includes/02_firewall.user_include
@@ -73,8 +73,8 @@ table inet fw4 {
 	# Defines
 	#
 
-	define test_devices = { "eth0" }
-	define test_subnets = {  }
+	redefine test_devices = { "eth0" }
+	redefine test_subnets = {  }
 
 
 	#

--- a/tests/06_includes/04_disabled_include
+++ b/tests/06_includes/04_disabled_include
@@ -79,8 +79,8 @@ table inet fw4 {
 	# Defines
 	#
 
-	define test_devices = { "eth0" }
-	define test_subnets = {  }
+	redefine test_devices = { "eth0" }
+	redefine test_subnets = {  }
 
 
 	#

--- a/tests/06_includes/05_automatic_includes
+++ b/tests/06_includes/05_automatic_includes
@@ -79,8 +79,8 @@ table inet fw4 {
 	# Defines
 	#
 
-	define test_devices = { "eth0" }
-	define test_subnets = {  }
+	redefine test_devices = { "eth0" }
+	redefine test_subnets = {  }
 
 
 	#


### PR DESCRIPTION
Use "redefine" in place of "define" in zone description macros to make firewall resilient against package mistakenly injecting duplicate zone definitions.

eg https://github.com/openwrt/packages/issues/29962