### PR TITLE
ruleset: use low-jitter vmap gadget to dispatch ct states

### DIFF
--- a/root/usr/share/firewall4/templates/ruleset.uc
+++ b/root/usr/share/firewall4/templates/ruleset.uc
@@ -106,16 +106,45 @@ table inet fw4 {
 
 
 	#
+	# vmap gadgets
+	#
+
+	chain input_states {
+		ct state vmap { invalid counter :{% if (fw4.default_option("drop_invalid")):%} drop{%else%} return{% endif %}, new : return, established : accept, related : accept, untracked : return }
+		counter drop
+	}
+
+	chain forward_states {
+		ct state vmap { invalid counter :{% if (fw4.default_option("drop_invalid")):%} drop{%else%} return{% endif %}, new : return, established : goto handle_offload, related :{% if (fw4.default_option("flow_offloading_related")): %} goto handle_offload{%else%} accept{%endif%}, untracked : return }
+		counter drop
+	}
+
+	chain output_states {
+		ct state vmap { invalid counter :{% if (fw4.default_option("drop_invalid")):%} drop{%else%} return{% endif %}, new : return, established : accept, related : accept, untracked : return }
+		counter drop
+	}
+
+	chain drop_invalid {
+		ct state vmap { invalid counter : drop, new : return, established : return, related : return, untracked : return }
+		counter drop
+	}
+
+	chain handle_offload {
+	{% if (length(flowtable_devices) > 0): %}
+		flow add @ft accept
+	{% endif %}
+		accept
+	}
+
+	#
 	# Filter rules
 	#
 
 	chain input {
 		type filter hook input priority filter; policy {{ fw4.input_policy(true) }};
-
-		iif "lo" accept comment "!fw4: Accept traffic from loopback"
-
 {% fw4.includes('chain-prepend', 'input') %}
-		ct state vmap { established : accept, related : accept{% if (fw4.default_option("drop_invalid")): %}, invalid : drop{% endif %} } comment "!fw4: Handle inbound flows"
+		jump input_states
+		iif "lo" accept comment "!fw4: Accept traffic from loopback"
 {% if (fw4.default_option("synflood_protect") && fw4.default_option("synflood_rate")): %}
 		tcp flags & (fin | syn | rst | ack) == syn jump syn_flood comment "!fw4: Rate limit TCP syn packets"
 {% endif %}
@@ -126,7 +155,7 @@ table inet fw4 {
 		{%+ include("zone-jump.uc", { fw4, zone, rule, direction: "input" }) %}
 {% endfor; endfor %}
 {% if (fw4.input_policy() == "reject"): %}
-		jump handle_reject
+		goto handle_reject
 {% endif %}
 {% fw4.includes('chain-append', 'input') %}
 	}
@@ -134,11 +163,8 @@ table inet fw4 {
 	chain forward {
 		type filter hook forward priority filter; policy {{ fw4.forward_policy(true) }};
 
-{% if (length(flowtable_devices) > 0): %}
-		meta l4proto { tcp, udp } flow offload @ft;
-{% endif %}
 {% fw4.includes('chain-prepend', 'forward') %}
-		ct state vmap { established : accept, related : accept{% if (fw4.default_option("drop_invalid")): %}, invalid : drop{% endif %} } comment "!fw4: Handle forwarded flows"
+		jump forward_states
 {% for (let rule in fw4.rules("forward")): %}
 		{%+ include("rule.uc", { fw4, zone: (rule.src?.zone?.log_limit ? rule.src.zone : rule.dest?.zone), rule }) %}
 {% endfor %}
@@ -147,17 +173,15 @@ table inet fw4 {
 {% endfor; endfor %}
 {% fw4.includes('chain-append', 'forward') %}
 {% if (fw4.forward_policy() == "reject"): %}
-		jump handle_reject
+		goto handle_reject
 {% endif %}
 	}
 
 	chain output {
 		type filter hook output priority filter; policy {{ fw4.output_policy(true) }};
-
-		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
-
 {% fw4.includes('chain-prepend', 'output') %}
-		ct state vmap { established : accept, related : accept{% if (fw4.default_option("drop_invalid")): %}, invalid : drop{% endif %} } comment "!fw4: Handle outbound flows"
+		jump output_states
+		oif "lo" accept comment "!fw4: Accept traffic towards loopback"
 {% for (let rule in fw4.rules("output")): %}
 		{%+ include("rule.uc", { fw4, zone: null, rule }) %}
 {% endfor %}
@@ -175,7 +199,7 @@ table inet fw4 {
 {% endfor %}
 {% fw4.includes('chain-append', 'output') %}
 {% if (fw4.output_policy() == "reject"): %}
-		jump handle_reject
+		goto handle_reject
 {% endif %}
 	}
 
@@ -195,6 +219,9 @@ table inet fw4 {
 	}
 
 	chain handle_reject {
+{% if (!fw4.default_option("drop_invalid")): %}
+		jump drop_invalid
+{% endif %}
 		meta l4proto tcp reject with {{
 			(fw4.default_option("tcp_reject_code") != "tcp-reset")
 				? `icmpx type ${fw4.default_option("tcp_reject_code")}`

--- a/root/usr/share/firewall4/templates/zone-drop-invalid.uc
+++ b/root/usr/share/firewall4/templates/zone-drop-invalid.uc
@@ -1,13 +1,4 @@
 {%+ if (zone.masq ^ zone.masq6): -%}
 	meta nfproto {{ fw4.nfproto(zone.masq ? 4 : 6) }} {%+ endif -%}
 {%+ include("zone-match.uc", { egress: true, rule }) -%}
-ct state invalid {%+ if ((zone.log & 1) && zone.log_limit): -%}
-	limit name "{{ zone.name }}.log_limit" log prefix "drop {{ zone.name }} invalid ct state: "
-		{%+ include("zone-drop-invalid.uc", { fw4, zone: { ...zone, log: 0 }, rule }) %}
-{%+ else -%}
-{%+  if (zone.counter): -%}
-	counter {%+ endif -%}
-{%+  if (zone.log & 1): -%}
-	log prefix "drop {{ zone.name }} invalid ct state: " {%+ endif -%}
-drop comment "!fw4: Prevent NAT leakage"
-{%+ endif -%}
+	jump drop_invalid

--- a/root/usr/share/firewall4/templates/zone-verdict.uc
+++ b/root/usr/share/firewall4/templates/zone-verdict.uc
@@ -10,7 +10,7 @@
 {%+  if (verdict != "accept" && (zone.log & 1)): -%}
 	log prefix "{{ verdict }} {{ zone.name }} {{ egress ? "out" : "in" }}: " {%+ endif -%}
 {%   if (verdict == "reject"): -%}
-	jump handle_reject comment "!fw4: reject {{ zone.name }} {{ fw4.nfproto(rule.family, true) }} traffic"
+	goto handle_reject comment "!fw4: reject {{ zone.name }} {{ fw4.nfproto(rule.family, true) }} traffic"
 {%   else -%}
 	{{ verdict }} comment "!fw4: {{ verdict }} {{ zone.name }} {{ fw4.nfproto(rule.family, true) }} traffic"
 {%   endif -%}

--- a/root/usr/share/ucode/fw4.uc
+++ b/root/usr/share/ucode/fw4.uc
@@ -1971,6 +1971,7 @@ return {
 			disable_ipv6: [ "bool", null, UNSUPPORTED ],
 			flow_offloading: [ "bool", "0" ],
 			flow_offloading_hw: [ "bool", "0" ],
+			flow_offloading_related: [ "bool", "1"],
 
 			auto_includes: [ "bool", "1" ]
 		});


### PR DESCRIPTION
Measurably eliminates re-orders forwarding, as for online tests adds one grade to bufferbloat measurements in an instant

Throughput not affected, Archer C7V5(single-gmac ath79) exhibits 400Mbps throughput NAT or flat routing, over 650Mbps without firewall in flat config, sw offload reached bidirectional gigabit on gmac port at 65% CPU, should be able to approach but not reach gigabit with 2gmac device

- There are packets in two states at once, widgets frantically drop those REF: https://bugzilla.netfilter.org/show_bug.cgi?id=1834
- flow offload is postponed to tcp seq agreed / udp replied as offload engines skip basic ct validations and can ingest one-way half-state (ref https://github.com/openwrt/openwrt/pull/24873#issuecomment-5590817325)
- separate offload chain permits users to override offloads to their liking
- upfront parameter can disable offloading from related icmp so that margin conditions are handled by nft / kernel  
- Per-zone invalid logging gone, one can log them using sysctl
- Includes #49 #55 #56
Caveat: tests skipped, got some plans to add more around same lines, will fix them up if needed
